### PR TITLE
Feat/user search

### DIFF
--- a/src/main/java/team23/q_check/identity/controller/UserController.java
+++ b/src/main/java/team23/q_check/identity/controller/UserController.java
@@ -8,12 +8,16 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import team23.q_check.common.auth.CurrentUserId;
 import team23.q_check.common.response.ApiResponse;
 import team23.q_check.identity.dto.MyUserResponseDto;
 import team23.q_check.identity.dto.UpdateMyUserRequestDto;
+import team23.q_check.identity.dto.UserSearchResultDto;
 import team23.q_check.identity.domain.service.UserService;
+
+import java.util.List;
 
 @Tag(name = "User", description = "User API")
 @SecurityRequirement(name = "X-USER-ID")
@@ -44,5 +48,19 @@ public class UserController {
             @RequestBody UpdateMyUserRequestDto request
     ) {
         return ApiResponse.ok(userService.updateMyUser(currentUserId, request));
+    }
+
+    @Operation(
+            summary = "사용자 검색",
+            description = "닉네임(부분일치) 또는 이메일(정확매치)로 사용자를 검색합니다. " +
+                    "둘 중 하나는 반드시 입력해야 하며, 결과에는 이메일이 포함되지 않습니다. " +
+                    "닉네임 검색은 최대 20명까지 반환합니다."
+    )
+    @GetMapping("/search")
+    public ApiResponse<List<UserSearchResultDto>> searchUsers(
+            @Parameter(description = "닉네임 부분일치 (대소문자 무시)") @RequestParam(required = false) String nickname,
+            @Parameter(description = "이메일 정확매치") @RequestParam(required = false) String email
+    ) {
+        return ApiResponse.ok(userService.searchUsers(nickname, email));
     }
 }

--- a/src/main/java/team23/q_check/identity/domain/repository/UserRepository.java
+++ b/src/main/java/team23/q_check/identity/domain/repository/UserRepository.java
@@ -3,9 +3,13 @@ package team23.q_check.identity.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team23.q_check.identity.domain.model.User;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByUsername(String username);
+
+    /** 닉네임 부분일치 검색 (대소문자 무시). 검색 폭주를 막기 위해 상한을 둔다. */
+    List<User> findTop20ByUsernameContainingIgnoreCaseOrderByUsernameAsc(String fragment);
 }

--- a/src/main/java/team23/q_check/identity/domain/service/UserService.java
+++ b/src/main/java/team23/q_check/identity/domain/service/UserService.java
@@ -8,7 +8,10 @@ import team23.q_check.identity.domain.model.User;
 import team23.q_check.identity.dto.MyUserResponseDto;
 import team23.q_check.identity.dto.UpdateMyUserRequestDto;
 import team23.q_check.identity.dto.UserResponseDto;
+import team23.q_check.identity.dto.UserSearchResultDto;
 import team23.q_check.identity.domain.repository.UserRepository;
+
+import java.util.List;
 
 @Service
 public class UserService {
@@ -38,7 +41,36 @@ public class UserService {
         return toDto(user);
     }
 
+    /**
+     * 닉네임(부분일치) 또는 이메일(정확매치)로 사용자를 검색한다.
+     * 둘 중 하나는 비어있지 않아야 하며, 응답에 이메일은 포함하지 않는다.
+     */
+    @Transactional(readOnly = true)
+    public List<UserSearchResultDto> searchUsers(String nickname, String email) {
+        boolean hasNickname = nickname != null && !nickname.isBlank();
+        boolean hasEmail = email != null && !email.isBlank();
+        if (!hasNickname && !hasEmail) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "nickname or email is required");
+        }
+
+        if (hasEmail) {
+            return userRepository.findByEmail(email.trim())
+                    .map(user -> List.of(toSearchDto(user)))
+                    .orElse(List.of());
+        }
+
+        return userRepository
+                .findTop20ByUsernameContainingIgnoreCaseOrderByUsernameAsc(nickname.trim())
+                .stream()
+                .map(this::toSearchDto)
+                .toList();
+    }
+
     private MyUserResponseDto toDto(User user) {
         return new MyUserResponseDto(user.getId(), user.getUsername(), user.getRealName());
+    }
+
+    private UserSearchResultDto toSearchDto(User user) {
+        return new UserSearchResultDto(user.getId(), user.getUsername(), user.getRealName());
     }
 }

--- a/src/main/java/team23/q_check/identity/dto/UserSearchResultDto.java
+++ b/src/main/java/team23/q_check/identity/dto/UserSearchResultDto.java
@@ -1,0 +1,14 @@
+package team23.q_check.identity.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "사용자 검색 결과 DTO")
+public record UserSearchResultDto(
+        @Schema(example = "7")
+        Long userId,
+        @Schema(example = "kimjyun")
+        String username,
+        @Schema(example = "김지윤", description = "사용자가 등록한 실명. 등록하지 않았으면 null.")
+        String realName
+) {
+}

--- a/src/test/java/team23/q_check/identity/controller/UserControllerTest.java
+++ b/src/test/java/team23/q_check/identity/controller/UserControllerTest.java
@@ -9,7 +9,10 @@ import team23.q_check.common.auth.CurrentUserIdArgumentResolver;
 import team23.q_check.common.auth.JwtService;
 import team23.q_check.common.error.GlobalExceptionHandler;
 import team23.q_check.identity.dto.MyUserResponseDto;
+import team23.q_check.identity.dto.UserSearchResultDto;
 import team23.q_check.identity.domain.service.UserService;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -75,5 +78,34 @@ class UserControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.code").value("INVALID_REQUEST"));
+    }
+
+    @Test
+    void searchUsers_byNickname_returnsList() throws Exception {
+        when(userService.searchUsers("kim", null)).thenReturn(List.of(
+                new UserSearchResultDto(1L, "kimjyun", "김지윤"),
+                new UserSearchResultDto(2L, "kimminseo", null)
+        ));
+
+        mockMvc.perform(get("/api/users/search?nickname=kim").header("X-USER-ID", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0].userId").value(1))
+                .andExpect(jsonPath("$.data[0].username").value("kimjyun"))
+                .andExpect(jsonPath("$.data[0].realName").value("김지윤"))
+                .andExpect(jsonPath("$.data[0].email").doesNotExist());
+    }
+
+    @Test
+    void searchUsers_byEmail_returnsSingle() throws Exception {
+        when(userService.searchUsers(null, "kim@example.com")).thenReturn(List.of(
+                new UserSearchResultDto(1L, "kimjyun", "김지윤")
+        ));
+
+        mockMvc.perform(get("/api/users/search?email=kim@example.com").header("X-USER-ID", "1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.length()").value(1))
+                .andExpect(jsonPath("$.data[0].userId").value(1));
     }
 }

--- a/src/test/java/team23/q_check/identity/service/UserServiceTest.java
+++ b/src/test/java/team23/q_check/identity/service/UserServiceTest.java
@@ -3,17 +3,21 @@ package team23.q_check.identity.service;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import team23.q_check.common.error.AppException;
+import team23.q_check.common.error.ErrorCode;
 import team23.q_check.identity.domain.model.User;
 import team23.q_check.identity.domain.service.UserService;
 import team23.q_check.identity.dto.MyUserResponseDto;
 import team23.q_check.identity.dto.UpdateMyUserRequestDto;
+import team23.q_check.identity.dto.UserSearchResultDto;
 import team23.q_check.identity.domain.repository.UserRepository;
 
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -59,6 +63,67 @@ class UserServiceTest {
         when(userRepository.findById(99L)).thenReturn(Optional.empty());
 
         assertThrows(AppException.class, () -> userService.getMyUser(99L));
+    }
+
+    @Test
+    void searchUsers_byNickname_returnsMatchingList() throws Exception {
+        User u1 = new User("dev-1", "kimjyun");
+        u1.updateRealName("김지윤");
+        setId(u1, 1L);
+        User u2 = new User("dev-2", "kimminseo");
+        setId(u2, 2L);
+        when(userRepository.findTop20ByUsernameContainingIgnoreCaseOrderByUsernameAsc("kim"))
+                .thenReturn(List.of(u1, u2));
+
+        List<UserSearchResultDto> result = userService.searchUsers("kim", null);
+
+        assertEquals(2, result.size());
+        assertEquals(1L, result.get(0).userId());
+        assertEquals("kimjyun", result.get(0).username());
+        assertEquals("김지윤", result.get(0).realName());
+        assertEquals(2L, result.get(1).userId());
+    }
+
+    @Test
+    void searchUsers_byEmail_returnsSingleResult() throws Exception {
+        User u1 = new User("dev-1", "kimjyun");
+        setId(u1, 1L);
+        when(userRepository.findByEmail("kim@example.com")).thenReturn(Optional.of(u1));
+
+        List<UserSearchResultDto> result = userService.searchUsers(null, "kim@example.com");
+
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).userId());
+    }
+
+    @Test
+    void searchUsers_byEmail_whenNotFound_returnsEmptyList() {
+        when(userRepository.findByEmail("nope@example.com")).thenReturn(Optional.empty());
+
+        List<UserSearchResultDto> result = userService.searchUsers(null, "nope@example.com");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void searchUsers_whenBothEmpty_throwsInvalidRequest() {
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> userService.searchUsers("  ", null)
+        );
+        assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    void searchUsers_emailTakesPriorityOverNickname() throws Exception {
+        User u1 = new User("dev-1", "kimjyun");
+        setId(u1, 1L);
+        when(userRepository.findByEmail("kim@example.com")).thenReturn(Optional.of(u1));
+
+        List<UserSearchResultDto> result = userService.searchUsers("kim", "kim@example.com");
+
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).userId());
     }
 
     private void setId(User user, Long id) throws Exception {


### PR DESCRIPTION
## 추가된 endpoint
GET /api/users/search?nickname={fragment}&email={exact}                                                                                                                                                                               
                                                                                                                                                                                                                                        
  ## 설명
- 인증 필요 (X-USER-ID)                                                                                                                                                                                                               
- nickname: 부분일치, 대소문자 무시, 최대 20명, username 알파벳순                                                                                                                                                                     
- email: 정확매치, 0 또는 1명                                                                                                                                                                                                         
- 둘 다 비어있으면 400                                                                                                                                                                                                                
- 둘 다 들어오면 email 우선                                                                                                                                                                                                           
- 응답에 email 미포함 (검색자에게 노출되지 않게)                                                                                                                                                                                      
                                                                                                                                                                                                                                        
  응답 예: 
```java
  {
    "success": true,  
    "data": [  
      { "userId": 1, "username": "kimjyun", "realName": "김지윤" },
      { "userId": 2, "username": "kimminseo", "realName": null } 
    ]  
  }
```
      