### PR TITLE
Feat/lifecycle endpoints

### DIFF
--- a/src/main/java/team23/q_check/club/controller/ClubController.java
+++ b/src/main/java/team23/q_check/club/controller/ClubController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -85,6 +86,31 @@ public class ClubController {
             @RequestBody UpdateClubMemberRoleRequestDto request
     ) {
         return ApiResponse.ok(clubService.updateClubMemberRole(currentUserId, clubId, memberId, request));
+    }
+
+    @Operation(summary = "클럽 탈퇴 (본인)",
+            description = "본인이 마지막 OWNER이면 409 (먼저 다른 사람에게 OWNER 위임 필요).")
+    @DeleteMapping("/{clubId}/members/me")
+    public ApiResponse<Void> leaveClub(
+            @Parameter(hidden = true)
+            @CurrentUserId Long currentUserId,
+            @PathVariable Long clubId
+    ) {
+        clubService.leaveClub(currentUserId, clubId);
+        return ApiResponse.ok(null);
+    }
+
+    @Operation(summary = "클럽 멤버 제거 (OWNER/ADMIN)",
+            description = "ADMIN은 OWNER를 제거할 수 없으며, 본인을 제거하려면 /me 엔드포인트를 사용해야 합니다.")
+    @DeleteMapping("/{clubId}/members/{memberId}")
+    public ApiResponse<Void> removeClubMember(
+            @Parameter(hidden = true)
+            @CurrentUserId Long currentUserId,
+            @PathVariable Long clubId,
+            @PathVariable Long memberId
+    ) {
+        clubService.removeClubMember(currentUserId, clubId, memberId);
+        return ApiResponse.ok(null);
     }
 
     @Operation(summary = "샘플 동아리 조회")

--- a/src/main/java/team23/q_check/club/domain/repository/ClubMemberRepository.java
+++ b/src/main/java/team23/q_check/club/domain/repository/ClubMemberRepository.java
@@ -2,6 +2,7 @@ package team23.q_check.club.domain.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import team23.q_check.club.domain.model.ClubMember;
+import team23.q_check.club.domain.model.ClubRole;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,4 +17,6 @@ public interface ClubMemberRepository extends JpaRepository<ClubMember, Long> {
     boolean existsByClub_IdAndUser_Id(Long clubId, Long userId);
 
     Optional<ClubMember> findByIdAndClub_Id(Long memberId, Long clubId);
+
+    long countByClub_IdAndRole(Long clubId, ClubRole role);
 }

--- a/src/main/java/team23/q_check/club/domain/service/ClubService.java
+++ b/src/main/java/team23/q_check/club/domain/service/ClubService.java
@@ -117,6 +117,50 @@ public class ClubService {
         );
     }
 
+    /**
+     * 본인이 클럽에서 탈퇴한다. 마지막 OWNER이면 거부 (먼저 위임 필요).
+     */
+    @Transactional
+    public void leaveClub(Long currentUserId, Long clubId) {
+        ClubMember membership = clubAuthorizationService.requireMembership(clubId, currentUserId);
+        if (membership.getRole() == ClubRole.OWNER && isLastOwner(clubId)) {
+            throw new AppException(ErrorCode.CONFLICT,
+                    "Last OWNER cannot leave the club. Transfer ownership first.");
+        }
+        clubMemberRepository.delete(membership);
+    }
+
+    /**
+     * 관리자(OWNER/ADMIN)가 다른 멤버를 클럽에서 제거한다.
+     * - ADMIN은 OWNER를 제거할 수 없다
+     * - 마지막 OWNER는 제거할 수 없다 (사실상 OWNER끼리만 가능한 상황에서만 차단)
+     * - 본인을 이 엔드포인트로 제거하는 것은 거부 (탈퇴는 /me 엔드포인트 사용)
+     */
+    @Transactional
+    public void removeClubMember(Long currentUserId, Long clubId, Long memberId) {
+        ClubMember operator = clubAuthorizationService.requireAdminOrOwner(clubId, currentUserId);
+        ClubMember target = clubMemberRepository.findByIdAndClub_Id(memberId, clubId)
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "Club member not found: " + memberId));
+
+        if (target.getId().equals(operator.getId())) {
+            throw new AppException(ErrorCode.INVALID_REQUEST,
+                    "Use the leave endpoint to remove yourself");
+        }
+        if (operator.getRole() == ClubRole.ADMIN && target.getRole() == ClubRole.OWNER) {
+            throw new AppException(ErrorCode.FORBIDDEN, "ADMIN cannot remove an OWNER");
+        }
+        if (target.getRole() == ClubRole.OWNER && isLastOwner(clubId)) {
+            throw new AppException(ErrorCode.CONFLICT,
+                    "Last OWNER cannot be removed. Transfer ownership first.");
+        }
+
+        clubMemberRepository.delete(target);
+    }
+
+    private boolean isLastOwner(Long clubId) {
+        return clubMemberRepository.countByClub_IdAndRole(clubId, ClubRole.OWNER) <= 1L;
+    }
+
     @Transactional
     public ClubMemberResponseDto updateClubMemberRole(
             Long currentUserId,

--- a/src/main/java/team23/q_check/event/controller/EventController.java
+++ b/src/main/java/team23/q_check/event/controller/EventController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -100,6 +101,19 @@ public class EventController {
             @RequestBody CreateRegistrationRequestDto request
     ) {
         return ApiResponse.ok(registrationService.createRegistration(currentUserId, eventId, request));
+    }
+
+    @Operation(summary = "내 참가 신청 취소",
+            description = "행사 시작 전, REGISTERED 상태일 때만 가능. " +
+                    "이미 CHECKED_IN이거나 CANCELED면 409.")
+    @PatchMapping("/{eventId}/registrations/me/cancel")
+    public ApiResponse<Void> cancelMyRegistration(
+            @Parameter(hidden = true)
+            @CurrentUserId Long currentUserId,
+            @PathVariable Long eventId
+    ) {
+        registrationService.cancelMyRegistration(currentUserId, eventId);
+        return ApiResponse.ok(null);
     }
 
     @Operation(summary = "내 참가 신청 조회")

--- a/src/main/java/team23/q_check/event/controller/EventController.java
+++ b/src/main/java/team23/q_check/event/controller/EventController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -64,6 +65,19 @@ public class EventController {
     @GetMapping("/{eventId}")
     public ApiResponse<EventDetailResponseDto> getEvent(@PathVariable Long eventId) {
         return ApiResponse.ok(eventService.getEvent(eventId));
+    }
+
+    @Operation(summary = "행사 삭제 (club ADMIN 이상)",
+            description = "활성 등록자(REGISTERED·CHECKED_IN)가 있으면 409. " +
+                    "단순 비활성화는 PUT 으로 isActive=false 를 사용하세요.")
+    @DeleteMapping("/{eventId}")
+    public ApiResponse<Void> deleteEvent(
+            @Parameter(hidden = true)
+            @CurrentUserId Long currentUserId,
+            @PathVariable Long eventId
+    ) {
+        eventService.deleteEvent(currentUserId, eventId);
+        return ApiResponse.ok(null);
     }
 
     @Operation(summary = "행사 수정 (club ADMIN 이상)")

--- a/src/main/java/team23/q_check/event/domain/repository/AttendanceLogRepository.java
+++ b/src/main/java/team23/q_check/event/domain/repository/AttendanceLogRepository.java
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import team23.q_check.event.domain.model.AttendanceLog;
 
 public interface AttendanceLogRepository extends JpaRepository<AttendanceLog, Long> {
+
+    void deleteAllByEvent_Id(Long eventId);
 }

--- a/src/main/java/team23/q_check/event/domain/repository/FormAnswerRepository.java
+++ b/src/main/java/team23/q_check/event/domain/repository/FormAnswerRepository.java
@@ -9,4 +9,6 @@ public interface FormAnswerRepository extends JpaRepository<FormAnswer, Long> {
     List<FormAnswer> findAllByRegistration_Id(Long registrationId);
 
     List<FormAnswer> findAllByRegistration_Event_Id(Long eventId);
+
+    void deleteAllByRegistration_Event_Id(Long eventId);
 }

--- a/src/main/java/team23/q_check/event/domain/repository/RegistrationRepository.java
+++ b/src/main/java/team23/q_check/event/domain/repository/RegistrationRepository.java
@@ -21,4 +21,8 @@ public interface RegistrationRepository extends JpaRepository<Registration, Long
     @Query("SELECT r.event.id FROM Registration r WHERE r.user.id = :userId AND r.status IN :statuses")
     List<Long> findEventIdsByUserIdAndStatuses(@Param("userId") Long userId,
                                                @Param("statuses") List<RegistrationStatus> statuses);
+
+    boolean existsByEvent_IdAndStatusIn(Long eventId, List<RegistrationStatus> statuses);
+
+    void deleteAllByEvent_Id(Long eventId);
 }

--- a/src/main/java/team23/q_check/event/domain/service/EventService.java
+++ b/src/main/java/team23/q_check/event/domain/service/EventService.java
@@ -23,8 +23,12 @@ import team23.q_check.event.dto.EventPageResponseDto;
 import team23.q_check.event.dto.FormFieldRequestDto;
 import team23.q_check.event.dto.FormFieldResponseDto;
 import team23.q_check.event.dto.UpdateEventRequestDto;
+import team23.q_check.event.domain.model.RegistrationStatus;
+import team23.q_check.event.domain.repository.AttendanceLogRepository;
 import team23.q_check.event.domain.repository.EventRepository;
+import team23.q_check.event.domain.repository.FormAnswerRepository;
 import team23.q_check.event.domain.repository.FormFieldRepository;
+import team23.q_check.event.domain.repository.RegistrationRepository;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -36,6 +40,9 @@ public class EventService {
 
     private final EventRepository eventRepository;
     private final FormFieldRepository formFieldRepository;
+    private final RegistrationRepository registrationRepository;
+    private final FormAnswerRepository formAnswerRepository;
+    private final AttendanceLogRepository attendanceLogRepository;
     private final ClubRepository clubRepository;
     private final ClubAuthorizationService clubAuthorizationService;
     private final ObjectMapper objectMapper;
@@ -43,12 +50,18 @@ public class EventService {
     public EventService(
             EventRepository eventRepository,
             FormFieldRepository formFieldRepository,
+            RegistrationRepository registrationRepository,
+            FormAnswerRepository formAnswerRepository,
+            AttendanceLogRepository attendanceLogRepository,
             ClubRepository clubRepository,
             ClubAuthorizationService clubAuthorizationService,
             ObjectMapper objectMapper
     ) {
         this.eventRepository = eventRepository;
         this.formFieldRepository = formFieldRepository;
+        this.registrationRepository = registrationRepository;
+        this.formAnswerRepository = formAnswerRepository;
+        this.attendanceLogRepository = attendanceLogRepository;
         this.clubRepository = clubRepository;
         this.clubAuthorizationService = clubAuthorizationService;
         this.objectMapper = objectMapper;
@@ -120,6 +133,32 @@ public class EventService {
                 .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "Event not found: " + eventId));
         List<FormField> fields = formFieldRepository.findAllByEvent_IdOrderBySortOrderAsc(eventId);
         return toDetailDto(event, fields);
+    }
+
+    /**
+     * 행사를 hard delete 한다. 활성 등록자(REGISTERED 또는 CHECKED_IN)가 있으면 거부.
+     * 비활성화로 충분한 경우엔 PUT /api/events/{id} 의 isActive=false 를 사용할 것.
+     */
+    @Transactional
+    public void deleteEvent(Long currentUserId, Long eventId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "Event not found: " + eventId));
+        clubAuthorizationService.requireAdminOrOwner(event.getClub().getId(), currentUserId);
+
+        boolean hasActiveRegistrations = registrationRepository.existsByEvent_IdAndStatusIn(
+                eventId,
+                List.of(RegistrationStatus.REGISTERED, RegistrationStatus.CHECKED_IN)
+        );
+        if (hasActiveRegistrations) {
+            throw new AppException(ErrorCode.CONFLICT,
+                    "Cannot delete an event with active registrations. Set isActive=false instead.");
+        }
+
+        attendanceLogRepository.deleteAllByEvent_Id(eventId);
+        formAnswerRepository.deleteAllByRegistration_Event_Id(eventId);
+        registrationRepository.deleteAllByEvent_Id(eventId);
+        formFieldRepository.deleteAllByEvent_Id(eventId);
+        eventRepository.delete(event);
     }
 
     @Transactional

--- a/src/main/java/team23/q_check/event/domain/service/RegistrationService.java
+++ b/src/main/java/team23/q_check/event/domain/service/RegistrationService.java
@@ -26,6 +26,7 @@ import team23.q_check.event.domain.repository.FormAnswerRepository;
 import team23.q_check.event.domain.repository.FormFieldRepository;
 import team23.q_check.event.domain.repository.RegistrationRepository;
 
+import java.time.LocalDateTime;
 import java.util.*;
 
 @Service
@@ -89,6 +90,30 @@ public class RegistrationService {
         }
 
         return new CreateRegistrationResponseDto(registration.getId(), registration.getQrToken());
+    }
+
+    /**
+     * 본인의 참가 신청을 취소한다. 행사 시작 전, REGISTERED 상태일 때만 가능.
+     * form_answers는 히스토리 보존을 위해 그대로 둔다.
+     */
+    @Transactional
+    public void cancelMyRegistration(Long currentUserId, Long eventId) {
+        Registration registration = registrationRepository.findByEvent_IdAndUser_Id(eventId, currentUserId)
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "Registration not found"));
+
+        if (registration.getStatus() == RegistrationStatus.CHECKED_IN) {
+            throw new AppException(ErrorCode.CONFLICT, "Cannot cancel a checked-in registration");
+        }
+        if (registration.getStatus() == RegistrationStatus.CANCELED) {
+            throw new AppException(ErrorCode.CONFLICT, "Registration is already canceled");
+        }
+
+        LocalDateTime startTime = registration.getEvent().getStartTime();
+        if (startTime != null && !LocalDateTime.now().isBefore(startTime)) {
+            throw new AppException(ErrorCode.CONFLICT, "Cannot cancel after event has started");
+        }
+
+        registration.updateStatus(RegistrationStatus.CANCELED);
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/team23/q_check/club/service/ClubServiceTest.java
+++ b/src/test/java/team23/q_check/club/service/ClubServiceTest.java
@@ -84,6 +84,147 @@ class ClubServiceTest {
     }
 
     @Test
+    void leaveClub_lastOwner_throwsConflict() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        setId(club, 1L);
+        User owner = new User("dev-1", "owner");
+        setId(owner, 1L);
+        ClubMember ownerMembership = new ClubMember(club, owner, ClubRole.OWNER);
+        setId(ownerMembership, 10L);
+
+        when(clubAuthorizationService.requireMembership(1L, 1L)).thenReturn(ownerMembership);
+        when(clubMemberRepository.countByClub_IdAndRole(1L, ClubRole.OWNER)).thenReturn(1L);
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> clubService.leaveClub(1L, 1L)
+        );
+        assertEquals(ErrorCode.CONFLICT, exception.getErrorCode());
+        verify(clubMemberRepository, never()).delete(any());
+    }
+
+    @Test
+    void leaveClub_memberLeavesSuccessfully() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        setId(club, 1L);
+        User member = new User("dev-2", "member");
+        setId(member, 2L);
+        ClubMember membership = new ClubMember(club, member, ClubRole.MEMBER);
+        setId(membership, 11L);
+
+        when(clubAuthorizationService.requireMembership(1L, 2L)).thenReturn(membership);
+
+        clubService.leaveClub(2L, 1L);
+
+        verify(clubMemberRepository).delete(membership);
+    }
+
+    @Test
+    void leaveClub_ownerWhenAnotherOwnerExists_succeeds() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        setId(club, 1L);
+        User owner = new User("dev-1", "owner");
+        setId(owner, 1L);
+        ClubMember ownerMembership = new ClubMember(club, owner, ClubRole.OWNER);
+        setId(ownerMembership, 10L);
+
+        when(clubAuthorizationService.requireMembership(1L, 1L)).thenReturn(ownerMembership);
+        when(clubMemberRepository.countByClub_IdAndRole(1L, ClubRole.OWNER)).thenReturn(2L);
+
+        clubService.leaveClub(1L, 1L);
+
+        verify(clubMemberRepository).delete(ownerMembership);
+    }
+
+    @Test
+    void removeClubMember_adminCannotRemoveOwner() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        setId(club, 1L);
+        User admin = new User("dev-1", "admin");
+        setId(admin, 1L);
+        User owner = new User("dev-2", "owner");
+        setId(owner, 2L);
+        ClubMember adminMembership = new ClubMember(club, admin, ClubRole.ADMIN);
+        setId(adminMembership, 10L);
+        ClubMember ownerMembership = new ClubMember(club, owner, ClubRole.OWNER);
+        setId(ownerMembership, 11L);
+
+        when(clubAuthorizationService.requireAdminOrOwner(1L, 1L)).thenReturn(adminMembership);
+        when(clubMemberRepository.findByIdAndClub_Id(11L, 1L)).thenReturn(Optional.of(ownerMembership));
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> clubService.removeClubMember(1L, 1L, 11L)
+        );
+        assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+        verify(clubMemberRepository, never()).delete(any());
+    }
+
+    @Test
+    void removeClubMember_cannotRemoveSelf() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        setId(club, 1L);
+        User admin = new User("dev-1", "admin");
+        setId(admin, 1L);
+        ClubMember adminMembership = new ClubMember(club, admin, ClubRole.ADMIN);
+        setId(adminMembership, 10L);
+
+        when(clubAuthorizationService.requireAdminOrOwner(1L, 1L)).thenReturn(adminMembership);
+        when(clubMemberRepository.findByIdAndClub_Id(10L, 1L)).thenReturn(Optional.of(adminMembership));
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> clubService.removeClubMember(1L, 1L, 10L)
+        );
+        assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    void removeClubMember_lastOwnerByOwner_throwsConflict() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        setId(club, 1L);
+        User owner1 = new User("dev-1", "owner1");
+        setId(owner1, 1L);
+        User owner2 = new User("dev-2", "owner2");
+        setId(owner2, 2L);
+        ClubMember owner1Membership = new ClubMember(club, owner1, ClubRole.OWNER);
+        setId(owner1Membership, 10L);
+        ClubMember owner2Membership = new ClubMember(club, owner2, ClubRole.OWNER);
+        setId(owner2Membership, 11L);
+
+        when(clubAuthorizationService.requireAdminOrOwner(1L, 1L)).thenReturn(owner1Membership);
+        when(clubMemberRepository.findByIdAndClub_Id(11L, 1L)).thenReturn(Optional.of(owner2Membership));
+        when(clubMemberRepository.countByClub_IdAndRole(1L, ClubRole.OWNER)).thenReturn(1L);
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> clubService.removeClubMember(1L, 1L, 11L)
+        );
+        assertEquals(ErrorCode.CONFLICT, exception.getErrorCode());
+    }
+
+    @Test
+    void removeClubMember_adminRemovesMemberSuccessfully() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        setId(club, 1L);
+        User admin = new User("dev-1", "admin");
+        setId(admin, 1L);
+        User member = new User("dev-2", "member");
+        setId(member, 2L);
+        ClubMember adminMembership = new ClubMember(club, admin, ClubRole.ADMIN);
+        setId(adminMembership, 10L);
+        ClubMember memberMembership = new ClubMember(club, member, ClubRole.MEMBER);
+        setId(memberMembership, 11L);
+
+        when(clubAuthorizationService.requireAdminOrOwner(1L, 1L)).thenReturn(adminMembership);
+        when(clubMemberRepository.findByIdAndClub_Id(11L, 1L)).thenReturn(Optional.of(memberMembership));
+
+        clubService.removeClubMember(1L, 1L, 11L);
+
+        verify(clubMemberRepository).delete(memberMembership);
+    }
+
+    @Test
     void updateClubMemberRole_adminCannotAssignOwner() throws Exception {
         Club club = new Club("UMC", "desc", "guild-1", null);
         setId(club, 1L);

--- a/src/test/java/team23/q_check/event/service/EventServiceTest.java
+++ b/src/test/java/team23/q_check/event/service/EventServiceTest.java
@@ -18,8 +18,11 @@ import team23.q_check.event.domain.model.form.FormField;
 import team23.q_check.event.dto.CreateEventRequestDto;
 import team23.q_check.event.dto.FormFieldRequestDto;
 import team23.q_check.event.dto.UpdateEventRequestDto;
+import team23.q_check.event.domain.repository.AttendanceLogRepository;
 import team23.q_check.event.domain.repository.EventRepository;
+import team23.q_check.event.domain.repository.FormAnswerRepository;
 import team23.q_check.event.domain.repository.FormFieldRepository;
+import team23.q_check.event.domain.repository.RegistrationRepository;
 
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
@@ -39,6 +42,9 @@ class EventServiceTest {
 
     private EventRepository eventRepository;
     private FormFieldRepository formFieldRepository;
+    private RegistrationRepository registrationRepository;
+    private FormAnswerRepository formAnswerRepository;
+    private AttendanceLogRepository attendanceLogRepository;
     private ClubRepository clubRepository;
     private ClubAuthorizationService clubAuthorizationService;
     private EventService eventService;
@@ -47,11 +53,17 @@ class EventServiceTest {
     void setUp() {
         eventRepository = mock(EventRepository.class);
         formFieldRepository = mock(FormFieldRepository.class);
+        registrationRepository = mock(RegistrationRepository.class);
+        formAnswerRepository = mock(FormAnswerRepository.class);
+        attendanceLogRepository = mock(AttendanceLogRepository.class);
         clubRepository = mock(ClubRepository.class);
         clubAuthorizationService = mock(ClubAuthorizationService.class);
         eventService = new EventService(
                 eventRepository,
                 formFieldRepository,
+                registrationRepository,
+                formAnswerRepository,
+                attendanceLogRepository,
                 clubRepository,
                 clubAuthorizationService,
                 new ObjectMapper()

--- a/src/test/java/team23/q_check/event/service/EventServiceTest.java
+++ b/src/test/java/team23/q_check/event/service/EventServiceTest.java
@@ -262,6 +262,52 @@ class EventServiceTest {
     }
 
     @Test
+    void deleteEvent_whenActiveRegistrationExists_throwsConflict() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        setId(club, 1L);
+        Event event = new Event(club, "OT",
+                LocalDateTime.parse("2026-03-10T19:00:00"),
+                LocalDateTime.parse("2026-03-10T20:00:00"),
+                null, true);
+        setId(event, 100L);
+        when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+        when(registrationRepository.existsByEvent_IdAndStatusIn(
+                org.mockito.ArgumentMatchers.eq(100L),
+                org.mockito.ArgumentMatchers.anyList()
+        )).thenReturn(true);
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> eventService.deleteEvent(1L, 100L)
+        );
+        assertEquals(ErrorCode.CONFLICT, exception.getErrorCode());
+    }
+
+    @Test
+    void deleteEvent_cascadesChildrenAndDeletesEvent() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        setId(club, 1L);
+        Event event = new Event(club, "OT",
+                LocalDateTime.parse("2026-03-10T19:00:00"),
+                LocalDateTime.parse("2026-03-10T20:00:00"),
+                null, true);
+        setId(event, 100L);
+        when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+        when(registrationRepository.existsByEvent_IdAndStatusIn(
+                org.mockito.ArgumentMatchers.eq(100L),
+                org.mockito.ArgumentMatchers.anyList()
+        )).thenReturn(false);
+
+        eventService.deleteEvent(1L, 100L);
+
+        verify(attendanceLogRepository).deleteAllByEvent_Id(100L);
+        verify(formAnswerRepository).deleteAllByRegistration_Event_Id(100L);
+        verify(registrationRepository).deleteAllByEvent_Id(100L);
+        verify(formFieldRepository).deleteAllByEvent_Id(100L);
+        verify(eventRepository).delete(event);
+    }
+
+    @Test
     void event_defaultConstructor_initializesRegisterFeeToZero() throws Exception {
         Club club = new Club("UMC", "desc", "guild-1", null);
         Event event = new Event(club, "OT",

--- a/src/test/java/team23/q_check/event/service/RegistrationServiceTest.java
+++ b/src/test/java/team23/q_check/event/service/RegistrationServiceTest.java
@@ -202,6 +202,92 @@ class RegistrationServiceTest {
         assertEquals("한식", result.answers().get(0).value());
     }
 
+    @Test
+    void cancelMyRegistration_whenRegistered_transitionsToCanceled() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        Event event = new Event(club, "OT",
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(1).plusHours(2),
+                null, true);
+        User user = new User("dev-1", "kim");
+        setId(user, 1L);
+        Registration registration = new Registration(event, user, "token-1",
+                team23.q_check.event.domain.model.RegistrationStatus.REGISTERED);
+        setId(registration, 200L);
+
+        when(registrationRepository.findByEvent_IdAndUser_Id(100L, 1L)).thenReturn(java.util.Optional.of(registration));
+
+        registrationService.cancelMyRegistration(1L, 100L);
+
+        assertEquals(team23.q_check.event.domain.model.RegistrationStatus.CANCELED, registration.getStatus());
+    }
+
+    @Test
+    void cancelMyRegistration_whenAlreadyCheckedIn_throwsConflict() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        Event event = new Event(club, "OT",
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(1).plusHours(2),
+                null, true);
+        User user = new User("dev-1", "kim");
+        setId(user, 1L);
+        Registration registration = new Registration(event, user, "token-1",
+                team23.q_check.event.domain.model.RegistrationStatus.CHECKED_IN);
+        setId(registration, 200L);
+
+        when(registrationRepository.findByEvent_IdAndUser_Id(100L, 1L)).thenReturn(java.util.Optional.of(registration));
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> registrationService.cancelMyRegistration(1L, 100L)
+        );
+        assertEquals(ErrorCode.CONFLICT, exception.getErrorCode());
+    }
+
+    @Test
+    void cancelMyRegistration_whenAlreadyCanceled_throwsConflict() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        Event event = new Event(club, "OT",
+                LocalDateTime.now().plusDays(1),
+                LocalDateTime.now().plusDays(1).plusHours(2),
+                null, true);
+        User user = new User("dev-1", "kim");
+        setId(user, 1L);
+        Registration registration = new Registration(event, user, "token-1",
+                team23.q_check.event.domain.model.RegistrationStatus.CANCELED);
+        setId(registration, 200L);
+
+        when(registrationRepository.findByEvent_IdAndUser_Id(100L, 1L)).thenReturn(java.util.Optional.of(registration));
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> registrationService.cancelMyRegistration(1L, 100L)
+        );
+        assertEquals(ErrorCode.CONFLICT, exception.getErrorCode());
+    }
+
+    @Test
+    void cancelMyRegistration_whenEventStarted_throwsConflict() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        Event event = new Event(club, "OT",
+                LocalDateTime.now().minusHours(1),
+                LocalDateTime.now().plusHours(1),
+                null, true);
+        User user = new User("dev-1", "kim");
+        setId(user, 1L);
+        Registration registration = new Registration(event, user, "token-1",
+                team23.q_check.event.domain.model.RegistrationStatus.REGISTERED);
+        setId(registration, 200L);
+
+        when(registrationRepository.findByEvent_IdAndUser_Id(100L, 1L)).thenReturn(java.util.Optional.of(registration));
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> registrationService.cancelMyRegistration(1L, 100L)
+        );
+        assertEquals(ErrorCode.CONFLICT, exception.getErrorCode());
+    }
+
     private void setId(Object target, Long id) throws Exception {
         Field field = target.getClass().getDeclaredField("id");
         field.setAccessible(true);


### PR DESCRIPTION
<img width="831" height="199" alt="image" src="https://github.com/user-attachments/assets/2d66d043-270f-4ad5-a095-9492268399a9" />

## 구현 내용
- 행사 삭제: 활성 등록자(REGISTERED·CHECKED_IN) 있으면 409
   - 단순 비활성화는 PUT isActive=false 로
   - 삭제 시 form_fields·form_answers·attendance_logs·CANCELED registrations 함께 정리                                     
- 참가 취소: REGISTERED + 시작 전 + 본인만 
    - 멱등성 X (이미 취소 상태면 409)
    - form_answers는 히스토리 보존
- 멤버 제거/탈퇴: ADMIN은 OWNER 제거 불가
   - 마지막 OWNER 보호. 관리자가 본인 제거 시도 → /me 사용 안내(400)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 클럽 멤버가 클럽에서 탈출할 수 있는 기능 추가
  * 클럽 소유자/관리자가 멤버를 제거할 수 있는 기능 추가
  * 관리자가 이벤트를 삭제할 수 있는 기능 추가
  * 사용자가 이벤트 등록을 취소할 수 있는 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->