### PR TITLE
Feat/event photos

### DIFF
--- a/src/main/java/team23/q_check/event/controller/EventPhotoController.java
+++ b/src/main/java/team23/q_check/event/controller/EventPhotoController.java
@@ -1,0 +1,70 @@
+package team23.q_check.event.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import team23.q_check.common.auth.CurrentUserId;
+import team23.q_check.common.response.ApiResponse;
+import team23.q_check.event.domain.service.EventPhotoService;
+import team23.q_check.event.dto.EventPhotoResponseDto;
+import team23.q_check.event.dto.UploadEventPhotoRequestDto;
+
+import java.util.List;
+
+@Tag(name = "Event Photo", description = "행사 사진 API")
+@SecurityRequirement(name = "X-USER-ID")
+@RestController
+@RequestMapping("/api/events/{eventId}/photos")
+public class EventPhotoController {
+
+    private final EventPhotoService eventPhotoService;
+
+    public EventPhotoController(EventPhotoService eventPhotoService) {
+        this.eventPhotoService = eventPhotoService;
+    }
+
+    @Operation(summary = "행사 사진 업로드 (URL 등록)",
+            description = "외부 스토리지에 이미 업로드된 이미지의 URL을 행사에 첨부합니다. " +
+                    "클럽 멤버 누구나 가능합니다.")
+    @PostMapping
+    public ApiResponse<EventPhotoResponseDto> uploadPhoto(
+            @Parameter(hidden = true)
+            @CurrentUserId Long currentUserId,
+            @PathVariable Long eventId,
+            @RequestBody UploadEventPhotoRequestDto request
+    ) {
+        return ApiResponse.ok(eventPhotoService.uploadPhoto(currentUserId, eventId, request));
+    }
+
+    @Operation(summary = "행사 사진 목록 조회",
+            description = "최신순으로 정렬해서 반환합니다. 클럽 멤버 누구나 조회 가능.")
+    @GetMapping
+    public ApiResponse<List<EventPhotoResponseDto>> getEventPhotos(
+            @Parameter(hidden = true)
+            @CurrentUserId Long currentUserId,
+            @PathVariable Long eventId
+    ) {
+        return ApiResponse.ok(eventPhotoService.getEventPhotos(currentUserId, eventId));
+    }
+
+    @Operation(summary = "행사 사진 삭제",
+            description = "본인이 업로드한 사진이거나 클럽 ADMIN/OWNER일 때만 삭제할 수 있습니다.")
+    @DeleteMapping("/{photoId}")
+    public ApiResponse<Void> deletePhoto(
+            @Parameter(hidden = true)
+            @CurrentUserId Long currentUserId,
+            @PathVariable Long eventId,
+            @PathVariable Long photoId
+    ) {
+        eventPhotoService.deletePhoto(currentUserId, eventId, photoId);
+        return ApiResponse.ok(null);
+    }
+}

--- a/src/main/java/team23/q_check/event/domain/model/EventPhoto.java
+++ b/src/main/java/team23/q_check/event/domain/model/EventPhoto.java
@@ -24,6 +24,35 @@ public class EventPhoto {
     @Column(nullable = false, length = 255)
     private String photoUrl;
 
-    @Column(nullable = false, length = 255)
-    private LocalDateTime createdAt =  LocalDateTime.now(ZoneOffset.UTC);
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt = LocalDateTime.now(ZoneOffset.UTC);
+
+    protected EventPhoto() {
+    }
+
+    public EventPhoto(Event event, User uploader, String photoUrl) {
+        this.event = event;
+        this.uploader = uploader;
+        this.photoUrl = photoUrl;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Event getEvent() {
+        return event;
+    }
+
+    public User getUploader() {
+        return uploader;
+    }
+
+    public String getPhotoUrl() {
+        return photoUrl;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
 }

--- a/src/main/java/team23/q_check/event/domain/repository/EventPhotoRepository.java
+++ b/src/main/java/team23/q_check/event/domain/repository/EventPhotoRepository.java
@@ -1,0 +1,16 @@
+package team23.q_check.event.domain.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team23.q_check.event.domain.model.EventPhoto;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EventPhotoRepository extends JpaRepository<EventPhoto, Long> {
+
+    List<EventPhoto> findAllByEvent_IdOrderByCreatedAtDesc(Long eventId);
+
+    Optional<EventPhoto> findByIdAndEvent_Id(Long photoId, Long eventId);
+
+    void deleteAllByEvent_Id(Long eventId);
+}

--- a/src/main/java/team23/q_check/event/domain/service/EventPhotoService.java
+++ b/src/main/java/team23/q_check/event/domain/service/EventPhotoService.java
@@ -1,0 +1,121 @@
+package team23.q_check.event.domain.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team23.q_check.club.domain.model.ClubMember;
+import team23.q_check.club.domain.model.ClubRole;
+import team23.q_check.club.domain.service.ClubAuthorizationService;
+import team23.q_check.common.error.AppException;
+import team23.q_check.common.error.ErrorCode;
+import team23.q_check.event.domain.model.Event;
+import team23.q_check.event.domain.model.EventPhoto;
+import team23.q_check.event.domain.repository.EventPhotoRepository;
+import team23.q_check.event.domain.repository.EventRepository;
+import team23.q_check.event.dto.EventPhotoResponseDto;
+import team23.q_check.event.dto.UploadEventPhotoRequestDto;
+import team23.q_check.identity.domain.model.User;
+import team23.q_check.identity.domain.repository.UserRepository;
+
+import java.util.List;
+
+@Service
+public class EventPhotoService {
+
+    private static final int MAX_URL_LENGTH = 255;
+
+    private final EventPhotoRepository eventPhotoRepository;
+    private final EventRepository eventRepository;
+    private final UserRepository userRepository;
+    private final ClubAuthorizationService clubAuthorizationService;
+
+    public EventPhotoService(
+            EventPhotoRepository eventPhotoRepository,
+            EventRepository eventRepository,
+            UserRepository userRepository,
+            ClubAuthorizationService clubAuthorizationService
+    ) {
+        this.eventPhotoRepository = eventPhotoRepository;
+        this.eventRepository = eventRepository;
+        this.userRepository = userRepository;
+        this.clubAuthorizationService = clubAuthorizationService;
+    }
+
+    /** 클럽 멤버가 행사 사진 URL을 등록한다. */
+    @Transactional
+    public EventPhotoResponseDto uploadPhoto(Long currentUserId, Long eventId, UploadEventPhotoRequestDto request) {
+        String photoUrl = validatePhotoUrl(request);
+
+        Event event = getEvent(eventId);
+        clubAuthorizationService.requireMembership(event.getClub().getId(), currentUserId);
+
+        User uploader = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "User not found: " + currentUserId));
+
+        EventPhoto saved = eventPhotoRepository.save(new EventPhoto(event, uploader, photoUrl));
+        return toDto(saved);
+    }
+
+    /** 클럽 멤버에게 행사 사진을 최신순으로 보여준다. */
+    @Transactional(readOnly = true)
+    public List<EventPhotoResponseDto> getEventPhotos(Long currentUserId, Long eventId) {
+        Event event = getEvent(eventId);
+        clubAuthorizationService.requireMembership(event.getClub().getId(), currentUserId);
+
+        return eventPhotoRepository.findAllByEvent_IdOrderByCreatedAtDesc(eventId).stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    /**
+     * 사진을 삭제한다. 본인이 올린 사진이거나 클럽 ADMIN 이상이어야 한다.
+     * 일반 MEMBER가 다른 사람의 사진을 지우는 것은 거부.
+     */
+    @Transactional
+    public void deletePhoto(Long currentUserId, Long eventId, Long photoId) {
+        EventPhoto photo = eventPhotoRepository.findByIdAndEvent_Id(photoId, eventId)
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "Photo not found: " + photoId));
+
+        ClubMember membership = clubAuthorizationService.requireMembership(
+                photo.getEvent().getClub().getId(), currentUserId);
+
+        boolean isUploader = photo.getUploader().getId().equals(currentUserId);
+        boolean isAdminOrOwner = membership.getRole() == ClubRole.ADMIN
+                || membership.getRole() == ClubRole.OWNER;
+        if (!isUploader && !isAdminOrOwner) {
+            throw new AppException(ErrorCode.FORBIDDEN,
+                    "Only the uploader or club ADMIN/OWNER can delete this photo");
+        }
+
+        eventPhotoRepository.delete(photo);
+    }
+
+    private Event getEvent(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "Event not found: " + eventId));
+    }
+
+    private String validatePhotoUrl(UploadEventPhotoRequestDto request) {
+        if (request == null || request.photoUrl() == null) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "photoUrl is required");
+        }
+        String trimmed = request.photoUrl().trim();
+        if (trimmed.isEmpty()) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "photoUrl is required");
+        }
+        if (trimmed.length() > MAX_URL_LENGTH) {
+            throw new AppException(ErrorCode.INVALID_REQUEST,
+                    "photoUrl must be at most " + MAX_URL_LENGTH + " characters");
+        }
+        return trimmed;
+    }
+
+    private EventPhotoResponseDto toDto(EventPhoto photo) {
+        return new EventPhotoResponseDto(
+                photo.getId(),
+                photo.getPhotoUrl(),
+                photo.getUploader().getId(),
+                photo.getUploader().getUsername(),
+                photo.getCreatedAt().toString()
+        );
+    }
+}

--- a/src/main/java/team23/q_check/event/domain/service/EventService.java
+++ b/src/main/java/team23/q_check/event/domain/service/EventService.java
@@ -25,6 +25,7 @@ import team23.q_check.event.dto.FormFieldResponseDto;
 import team23.q_check.event.dto.UpdateEventRequestDto;
 import team23.q_check.event.domain.model.RegistrationStatus;
 import team23.q_check.event.domain.repository.AttendanceLogRepository;
+import team23.q_check.event.domain.repository.EventPhotoRepository;
 import team23.q_check.event.domain.repository.EventRepository;
 import team23.q_check.event.domain.repository.FormAnswerRepository;
 import team23.q_check.event.domain.repository.FormFieldRepository;
@@ -43,6 +44,7 @@ public class EventService {
     private final RegistrationRepository registrationRepository;
     private final FormAnswerRepository formAnswerRepository;
     private final AttendanceLogRepository attendanceLogRepository;
+    private final EventPhotoRepository eventPhotoRepository;
     private final ClubRepository clubRepository;
     private final ClubAuthorizationService clubAuthorizationService;
     private final ObjectMapper objectMapper;
@@ -53,6 +55,7 @@ public class EventService {
             RegistrationRepository registrationRepository,
             FormAnswerRepository formAnswerRepository,
             AttendanceLogRepository attendanceLogRepository,
+            EventPhotoRepository eventPhotoRepository,
             ClubRepository clubRepository,
             ClubAuthorizationService clubAuthorizationService,
             ObjectMapper objectMapper
@@ -62,6 +65,7 @@ public class EventService {
         this.registrationRepository = registrationRepository;
         this.formAnswerRepository = formAnswerRepository;
         this.attendanceLogRepository = attendanceLogRepository;
+        this.eventPhotoRepository = eventPhotoRepository;
         this.clubRepository = clubRepository;
         this.clubAuthorizationService = clubAuthorizationService;
         this.objectMapper = objectMapper;
@@ -158,6 +162,7 @@ public class EventService {
         formAnswerRepository.deleteAllByRegistration_Event_Id(eventId);
         registrationRepository.deleteAllByEvent_Id(eventId);
         formFieldRepository.deleteAllByEvent_Id(eventId);
+        eventPhotoRepository.deleteAllByEvent_Id(eventId);
         eventRepository.delete(event);
     }
 

--- a/src/main/java/team23/q_check/event/dto/EventPhotoResponseDto.java
+++ b/src/main/java/team23/q_check/event/dto/EventPhotoResponseDto.java
@@ -1,0 +1,18 @@
+package team23.q_check.event.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "행사 사진 응답 DTO")
+public record EventPhotoResponseDto(
+        @Schema(example = "501")
+        Long photoId,
+        @Schema(example = "https://cdn.example.com/photos/abc.jpg")
+        String photoUrl,
+        @Schema(example = "7")
+        Long uploaderUserId,
+        @Schema(example = "kimjyun")
+        String uploaderUsername,
+        @Schema(example = "2026-05-07T19:00:00")
+        String createdAt
+) {
+}

--- a/src/main/java/team23/q_check/event/dto/UploadEventPhotoRequestDto.java
+++ b/src/main/java/team23/q_check/event/dto/UploadEventPhotoRequestDto.java
@@ -1,0 +1,11 @@
+package team23.q_check.event.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "행사 사진 업로드 요청 DTO (URL 전용)")
+public record UploadEventPhotoRequestDto(
+        @Schema(description = "외부 스토리지에 이미 업로드된 이미지의 URL",
+                example = "https://cdn.example.com/photos/abc.jpg")
+        String photoUrl
+) {
+}

--- a/src/test/java/team23/q_check/event/service/EventPhotoServiceTest.java
+++ b/src/test/java/team23/q_check/event/service/EventPhotoServiceTest.java
@@ -1,0 +1,220 @@
+package team23.q_check.event.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import team23.q_check.club.domain.model.Club;
+import team23.q_check.club.domain.model.ClubMember;
+import team23.q_check.club.domain.model.ClubRole;
+import team23.q_check.club.domain.service.ClubAuthorizationService;
+import team23.q_check.common.error.AppException;
+import team23.q_check.common.error.ErrorCode;
+import team23.q_check.event.domain.model.Event;
+import team23.q_check.event.domain.model.EventPhoto;
+import team23.q_check.event.domain.repository.EventPhotoRepository;
+import team23.q_check.event.domain.repository.EventRepository;
+import team23.q_check.event.domain.service.EventPhotoService;
+import team23.q_check.event.dto.EventPhotoResponseDto;
+import team23.q_check.event.dto.UploadEventPhotoRequestDto;
+import team23.q_check.identity.domain.model.User;
+import team23.q_check.identity.domain.repository.UserRepository;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class EventPhotoServiceTest {
+
+    private EventPhotoRepository eventPhotoRepository;
+    private EventRepository eventRepository;
+    private UserRepository userRepository;
+    private ClubAuthorizationService clubAuthorizationService;
+    private EventPhotoService eventPhotoService;
+
+    @BeforeEach
+    void setUp() {
+        eventPhotoRepository = mock(EventPhotoRepository.class);
+        eventRepository = mock(EventRepository.class);
+        userRepository = mock(UserRepository.class);
+        clubAuthorizationService = mock(ClubAuthorizationService.class);
+        eventPhotoService = new EventPhotoService(
+                eventPhotoRepository, eventRepository, userRepository, clubAuthorizationService
+        );
+    }
+
+    @Test
+    void uploadPhoto_savesAndReturnsDto() throws Exception {
+        Event event = newEvent();
+        User uploader = newUser(7L, "kimjyun");
+        when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+        when(clubAuthorizationService.requireMembership(1L, 7L))
+                .thenReturn(new ClubMember(event.getClub(), uploader, ClubRole.MEMBER));
+        when(userRepository.findById(7L)).thenReturn(Optional.of(uploader));
+        when(eventPhotoRepository.save(any(EventPhoto.class))).thenAnswer(invocation -> {
+            EventPhoto photo = invocation.getArgument(0);
+            setId(photo, 501L);
+            return photo;
+        });
+
+        EventPhotoResponseDto result = eventPhotoService.uploadPhoto(
+                7L, 100L, new UploadEventPhotoRequestDto("https://cdn.example.com/a.jpg"));
+
+        assertEquals(501L, result.photoId());
+        assertEquals("https://cdn.example.com/a.jpg", result.photoUrl());
+        assertEquals(7L, result.uploaderUserId());
+        assertEquals("kimjyun", result.uploaderUsername());
+
+        ArgumentCaptor<EventPhoto> captor = ArgumentCaptor.forClass(EventPhoto.class);
+        verify(eventPhotoRepository).save(captor.capture());
+        assertEquals("https://cdn.example.com/a.jpg", captor.getValue().getPhotoUrl());
+    }
+
+    @Test
+    void uploadPhoto_blankUrl_throwsBadRequest() throws Exception {
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> eventPhotoService.uploadPhoto(7L, 100L,
+                        new UploadEventPhotoRequestDto("   "))
+        );
+        assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    void uploadPhoto_urlTooLong_throwsBadRequest() {
+        String url = "https://" + "a".repeat(260);
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> eventPhotoService.uploadPhoto(7L, 100L, new UploadEventPhotoRequestDto(url))
+        );
+        assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    void uploadPhoto_nonMember_throwsForbidden() throws Exception {
+        Event event = newEvent();
+        when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+        when(clubAuthorizationService.requireMembership(1L, 99L))
+                .thenThrow(new AppException(ErrorCode.FORBIDDEN, "Not a member of this club"));
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> eventPhotoService.uploadPhoto(99L, 100L,
+                        new UploadEventPhotoRequestDto("https://cdn.example.com/a.jpg"))
+        );
+        assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+        verify(eventPhotoRepository, never()).save(any());
+    }
+
+    @Test
+    void getEventPhotos_returnsListInLatestFirstOrder() throws Exception {
+        Event event = newEvent();
+        User uploader = newUser(7L, "kimjyun");
+        EventPhoto p1 = new EventPhoto(event, uploader, "https://cdn.example.com/a.jpg");
+        EventPhoto p2 = new EventPhoto(event, uploader, "https://cdn.example.com/b.jpg");
+        setId(p1, 501L);
+        setId(p2, 502L);
+        when(eventRepository.findById(100L)).thenReturn(Optional.of(event));
+        when(clubAuthorizationService.requireMembership(1L, 7L))
+                .thenReturn(new ClubMember(event.getClub(), uploader, ClubRole.MEMBER));
+        when(eventPhotoRepository.findAllByEvent_IdOrderByCreatedAtDesc(100L)).thenReturn(List.of(p2, p1));
+
+        List<EventPhotoResponseDto> result = eventPhotoService.getEventPhotos(7L, 100L);
+
+        assertEquals(2, result.size());
+        assertEquals(502L, result.get(0).photoId());
+        assertEquals(501L, result.get(1).photoId());
+    }
+
+    @Test
+    void deletePhoto_byUploader_succeeds() throws Exception {
+        Event event = newEvent();
+        User uploader = newUser(7L, "kimjyun");
+        EventPhoto photo = new EventPhoto(event, uploader, "https://cdn.example.com/a.jpg");
+        setId(photo, 501L);
+        when(eventPhotoRepository.findByIdAndEvent_Id(501L, 100L)).thenReturn(Optional.of(photo));
+        when(clubAuthorizationService.requireMembership(1L, 7L))
+                .thenReturn(new ClubMember(event.getClub(), uploader, ClubRole.MEMBER));
+
+        eventPhotoService.deletePhoto(7L, 100L, 501L);
+
+        verify(eventPhotoRepository).delete(photo);
+    }
+
+    @Test
+    void deletePhoto_byAdminWhoIsNotUploader_succeeds() throws Exception {
+        Event event = newEvent();
+        User uploader = newUser(7L, "kimjyun");
+        User admin = newUser(1L, "admin");
+        EventPhoto photo = new EventPhoto(event, uploader, "https://cdn.example.com/a.jpg");
+        setId(photo, 501L);
+        when(eventPhotoRepository.findByIdAndEvent_Id(501L, 100L)).thenReturn(Optional.of(photo));
+        when(clubAuthorizationService.requireMembership(1L, 1L))
+                .thenReturn(new ClubMember(event.getClub(), admin, ClubRole.ADMIN));
+
+        eventPhotoService.deletePhoto(1L, 100L, 501L);
+
+        verify(eventPhotoRepository).delete(photo);
+    }
+
+    @Test
+    void deletePhoto_byOtherMember_throwsForbidden() throws Exception {
+        Event event = newEvent();
+        User uploader = newUser(7L, "kimjyun");
+        User other = newUser(8L, "other");
+        EventPhoto photo = new EventPhoto(event, uploader, "https://cdn.example.com/a.jpg");
+        setId(photo, 501L);
+        when(eventPhotoRepository.findByIdAndEvent_Id(501L, 100L)).thenReturn(Optional.of(photo));
+        when(clubAuthorizationService.requireMembership(1L, 8L))
+                .thenReturn(new ClubMember(event.getClub(), other, ClubRole.MEMBER));
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> eventPhotoService.deletePhoto(8L, 100L, 501L)
+        );
+        assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+        verify(eventPhotoRepository, never()).delete(any());
+    }
+
+    @Test
+    void deletePhoto_whenNotFound_throwsNotFound() {
+        when(eventPhotoRepository.findByIdAndEvent_Id(999L, 100L)).thenReturn(Optional.empty());
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> eventPhotoService.deletePhoto(1L, 100L, 999L)
+        );
+        assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());
+    }
+
+    private Event newEvent() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null);
+        setId(club, 1L);
+        Event event = new Event(club, "OT",
+                LocalDateTime.parse("2026-03-10T19:00:00"),
+                LocalDateTime.parse("2026-03-10T22:00:00"),
+                null, true);
+        setId(event, 100L);
+        return event;
+    }
+
+    private User newUser(Long id, String username) throws Exception {
+        User user = new User("dev-" + id, username);
+        setId(user, id);
+        return user;
+    }
+
+    private void setId(Object target, Long id) throws Exception {
+        Field field = target.getClass().getDeclaredField("id");
+        field.setAccessible(true);
+        field.set(target, id);
+    }
+}

--- a/src/test/java/team23/q_check/event/service/EventServiceTest.java
+++ b/src/test/java/team23/q_check/event/service/EventServiceTest.java
@@ -19,6 +19,7 @@ import team23.q_check.event.dto.CreateEventRequestDto;
 import team23.q_check.event.dto.FormFieldRequestDto;
 import team23.q_check.event.dto.UpdateEventRequestDto;
 import team23.q_check.event.domain.repository.AttendanceLogRepository;
+import team23.q_check.event.domain.repository.EventPhotoRepository;
 import team23.q_check.event.domain.repository.EventRepository;
 import team23.q_check.event.domain.repository.FormAnswerRepository;
 import team23.q_check.event.domain.repository.FormFieldRepository;
@@ -45,6 +46,7 @@ class EventServiceTest {
     private RegistrationRepository registrationRepository;
     private FormAnswerRepository formAnswerRepository;
     private AttendanceLogRepository attendanceLogRepository;
+    private EventPhotoRepository eventPhotoRepository;
     private ClubRepository clubRepository;
     private ClubAuthorizationService clubAuthorizationService;
     private EventService eventService;
@@ -56,6 +58,7 @@ class EventServiceTest {
         registrationRepository = mock(RegistrationRepository.class);
         formAnswerRepository = mock(FormAnswerRepository.class);
         attendanceLogRepository = mock(AttendanceLogRepository.class);
+        eventPhotoRepository = mock(EventPhotoRepository.class);
         clubRepository = mock(ClubRepository.class);
         clubAuthorizationService = mock(ClubAuthorizationService.class);
         eventService = new EventService(
@@ -64,6 +67,7 @@ class EventServiceTest {
                 registrationRepository,
                 formAnswerRepository,
                 attendanceLogRepository,
+                eventPhotoRepository,
                 clubRepository,
                 clubAuthorizationService,
                 new ObjectMapper()
@@ -304,6 +308,7 @@ class EventServiceTest {
         verify(formAnswerRepository).deleteAllByRegistration_Event_Id(100L);
         verify(registrationRepository).deleteAllByEvent_Id(100L);
         verify(formFieldRepository).deleteAllByEvent_Id(100L);
+        verify(eventPhotoRepository).deleteAllByEvent_Id(100L);
         verify(eventRepository).delete(event);
     }
 


### PR DESCRIPTION
## 추가된 endpoint
<img width="703" height="165" alt="image" src="https://github.com/user-attachments/assets/3c9368fa-5acd-4fbd-b477-280628b8ca3c" />

## 설명
- 저장: URL 전용 (photoUrl 문자열). trim 후 빈값/255자 초과 검증
- 업로드 권한: 클럽 멤버 누구나
- 조회 권한: 클럽 멤버 누구나 (멤버만 행사 사진 볼 수 있음)
- 삭제 권한: 본인이 올린 사진 OR 클럽 ADMIN/OWNER  
- 정렬: createdAt 내림차순