### PR TITLE
Feat/manual attendance

### DIFF
--- a/src/main/java/team23/q_check/event/controller/AttendanceController.java
+++ b/src/main/java/team23/q_check/event/controller/AttendanceController.java
@@ -12,6 +12,7 @@ import team23.q_check.common.auth.CurrentUserId;
 import team23.q_check.common.response.ApiResponse;
 import team23.q_check.event.dto.CheckInRequestDto;
 import team23.q_check.event.dto.CheckInResponseDto;
+import team23.q_check.event.dto.ManualCheckInRequestDto;
 import team23.q_check.event.domain.service.AttendanceService;
 
 @Tag(name = "Attendance", description = "Attendance API")
@@ -34,5 +35,19 @@ public class AttendanceController {
             @RequestBody CheckInRequestDto request
     ) {
         return ApiResponse.ok(attendanceService.checkIn(currentUserId, request.qrToken()));
+    }
+
+    @Operation(summary = "수동 체크인 (club ADMIN 이상)",
+            description = "QR 인식 실패·지각 등으로 관리자가 직접 출석 처리할 때 사용합니다. " +
+                    "참가 목록(GET /api/events/{eventId}/registrations)에서 얻은 " +
+                    "registrationId를 그대로 사용하면 됩니다. " +
+                    "이미 CHECKED_IN 이면 409.")
+    @PostMapping("/manual")
+    public ApiResponse<CheckInResponseDto> manualCheckIn(
+            @Parameter(hidden = true)
+            @CurrentUserId Long currentUserId,
+            @RequestBody ManualCheckInRequestDto request
+    ) {
+        return ApiResponse.ok(attendanceService.manualCheckIn(currentUserId, request.registrationId()));
     }
 }

--- a/src/main/java/team23/q_check/event/domain/model/AttendanceLog.java
+++ b/src/main/java/team23/q_check/event/domain/model/AttendanceLog.java
@@ -52,4 +52,8 @@ public class AttendanceLog {
     public Long getId() {
         return id;
     }
+
+    public AttendanceMethod getMethod() {
+        return method;
+    }
 }

--- a/src/main/java/team23/q_check/event/domain/service/AttendanceService.java
+++ b/src/main/java/team23/q_check/event/domain/service/AttendanceService.java
@@ -50,6 +50,22 @@ public class AttendanceService {
     }
 
     /**
+     * 관리자가 registrationId로 직접 체크인을 처리한다.
+     * QR 인식 실패·지각 등 운영 상황에서 사용한다.
+     */
+    @Transactional
+    public CheckInResponseDto manualCheckIn(Long currentUserId, Long registrationId) {
+        if (registrationId == null) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "registrationId is required");
+        }
+
+        Registration registration = registrationRepository.findById(registrationId)
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "Registration not found: " + registrationId));
+
+        return performCheckIn(currentUserId, registration, AttendanceMethod.MANUAL);
+    }
+
+    /**
      * 권한 검증·상태 전이·로그 생성 공통 흐름.
      * QR과 Manual이 공유한다.
      */

--- a/src/main/java/team23/q_check/event/domain/service/AttendanceService.java
+++ b/src/main/java/team23/q_check/event/domain/service/AttendanceService.java
@@ -46,6 +46,14 @@ public class AttendanceService {
         Registration registration = registrationRepository.findByQrToken(qrToken)
                 .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "Registration not found for qrToken"));
 
+        return performCheckIn(currentUserId, registration, AttendanceMethod.QR);
+    }
+
+    /**
+     * 권한 검증·상태 전이·로그 생성 공통 흐름.
+     * QR과 Manual이 공유한다.
+     */
+    private CheckInResponseDto performCheckIn(Long currentUserId, Registration registration, AttendanceMethod method) {
         clubAuthorizationService.requireAdminOrOwner(registration.getEvent().getClub().getId(), currentUserId);
 
         if (registration.getStatus() == RegistrationStatus.CHECKED_IN) {
@@ -63,7 +71,7 @@ public class AttendanceService {
                 registration,
                 checker,
                 now,
-                AttendanceMethod.QR
+                method
         );
         attendanceLogRepository.save(attendanceLog);
 

--- a/src/main/java/team23/q_check/event/dto/ManualCheckInRequestDto.java
+++ b/src/main/java/team23/q_check/event/dto/ManualCheckInRequestDto.java
@@ -1,0 +1,10 @@
+package team23.q_check.event.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "수동 체크인 요청 DTO")
+public record ManualCheckInRequestDto(
+        @Schema(example = "200")
+        Long registrationId
+) {
+}

--- a/src/test/java/team23/q_check/event/service/AttendanceServiceTest.java
+++ b/src/test/java/team23/q_check/event/service/AttendanceServiceTest.java
@@ -6,6 +6,9 @@ import team23.q_check.club.domain.model.Club;
 import team23.q_check.club.domain.service.ClubAuthorizationService;
 import team23.q_check.common.error.AppException;
 import team23.q_check.common.error.ErrorCode;
+import org.mockito.ArgumentCaptor;
+import team23.q_check.event.domain.model.AttendanceLog;
+import team23.q_check.event.domain.model.AttendanceMethod;
 import team23.q_check.event.domain.model.Event;
 import team23.q_check.event.domain.model.Registration;
 import team23.q_check.event.domain.model.RegistrationStatus;
@@ -82,6 +85,73 @@ class AttendanceServiceTest {
                 () -> attendanceService.checkIn(1L, " ")
         );
         assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    void manualCheckIn_success_updatesStatusAndSavesLogWithMethodManual() {
+        Registration registration = createRegistration(RegistrationStatus.REGISTERED);
+        User checker = new User("dev-admin", "admin");
+        checker.updateRealName("관리자");
+
+        when(registrationRepository.findById(200L)).thenReturn(Optional.of(registration));
+        when(userRepository.findById(1L)).thenReturn(Optional.of(checker));
+
+        var result = attendanceService.manualCheckIn(1L, 200L);
+
+        assertEquals(RegistrationStatus.CHECKED_IN, registration.getStatus());
+        assertEquals(200L, result.registrationId());
+        assertEquals("관리자", result.username());
+
+        ArgumentCaptor<AttendanceLog> captor = ArgumentCaptor.forClass(AttendanceLog.class);
+        verify(attendanceLogRepository).save(captor.capture());
+        assertEquals(AttendanceMethod.MANUAL, captor.getValue().getMethod());
+    }
+
+    @Test
+    void manualCheckIn_whenAlreadyCheckedIn_throwsConflict() {
+        Registration registration = createRegistration(RegistrationStatus.CHECKED_IN);
+        when(registrationRepository.findById(200L)).thenReturn(Optional.of(registration));
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> attendanceService.manualCheckIn(1L, 200L)
+        );
+        assertEquals(ErrorCode.CONFLICT, exception.getErrorCode());
+    }
+
+    @Test
+    void manualCheckIn_whenRegistrationIdMissing_throwsBadRequest() {
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> attendanceService.manualCheckIn(1L, null)
+        );
+        assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
+    }
+
+    @Test
+    void manualCheckIn_whenRegistrationNotFound_throwsNotFound() {
+        when(registrationRepository.findById(999L)).thenReturn(Optional.empty());
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> attendanceService.manualCheckIn(1L, 999L)
+        );
+        assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void manualCheckIn_whenNotAdmin_throwsForbidden() {
+        Registration registration = createRegistration(RegistrationStatus.REGISTERED);
+        when(registrationRepository.findById(200L)).thenReturn(Optional.of(registration));
+        doThrow(new AppException(ErrorCode.FORBIDDEN, "forbidden"))
+                .when(clubAuthorizationService).requireAdminOrOwner(any(), eq(99L));
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> attendanceService.manualCheckIn(99L, 200L)
+        );
+        assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
+        verify(attendanceLogRepository, never()).save(any());
     }
 
     private Registration createRegistration(RegistrationStatus status) {


### PR DESCRIPTION
## 추가된 endpoint
<img width="792" height="98" alt="image" src="https://github.com/user-attachments/assets/823c549a-2c86-4e8d-942f-e1b61dc77dbe" />

## 설명
- 권한: club ADMIN/OWNER (QR과 동일)
- 식별: registrationId (admin은 이미 GET /api/events/{id}/registrations로 목록 보고 있음)
- 상태 전이: REGISTERED → CHECKED_IN
- 이미 CHECKED_IN: 409 (QR과 동일)
- attendance_logs.method = MANUAL 기록                                                                                                                                                                                                
- 메모/사유 필드: 도입 안 함 (스키마 변경 부담 vs 가치 낮음)  