### PR TITLE
feat/#24: Self-hosted Runner CI/CD 파이프라인 구축

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# MySQL
+MYSQL_ROOT_PASSWORD=your_root_password
+MYSQL_USER=qcheck
+MYSQL_PASSWORD=your_password
+
+# Discord OAuth
+DISCORD_CLIENT_ID=your_discord_client_id
+DISCORD_CLIENT_SECRET=your_discord_client_secret
+DISCORD_REDIRECT_URI=http://localhost:8080/auth/code
+
+# JWT
+JWT_SECRET=your_jwt_secret_min_32_characters_long
+
+# CORS
+CORS_ALLOWED_ORIGINS=http://localhost:5173

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,28 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
+      - name: Create .env file
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.MYSQL_ROOT_PASSWORD }}
+          MYSQL_USER: ${{ secrets.MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+          DISCORD_CLIENT_ID: ${{ secrets.DISCORD_CLIENT_ID }}
+          DISCORD_CLIENT_SECRET: ${{ secrets.DISCORD_CLIENT_SECRET }}
+          DISCORD_REDIRECT_URI: ${{ secrets.DISCORD_REDIRECT_URI }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          CORS_ALLOWED_ORIGINS: ${{ secrets.CORS_ALLOWED_ORIGINS }}
+        run: |
+          cat > .env << EOF
+          MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+          MYSQL_USER=${MYSQL_USER}
+          MYSQL_PASSWORD=${MYSQL_PASSWORD}
+          DISCORD_CLIENT_ID=${DISCORD_CLIENT_ID}
+          DISCORD_CLIENT_SECRET=${DISCORD_CLIENT_SECRET}
+          DISCORD_REDIRECT_URI=${DISCORD_REDIRECT_URI}
+          JWT_SECRET=${JWT_SECRET}
+          CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS}
+          EOF
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy to Self-hosted Runner
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test --no-daemon
+
+      - name: Stop existing containers
+        run: docker compose down || true
+
+      - name: Build and start containers
+        run: docker compose up -d --build
+
+      - name: Health check
+        run: |
+          echo "Waiting for application to start..."
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/actuator/health > /dev/null 2>&1 || curl -sf http://localhost:8080/swagger-ui.html > /dev/null 2>&1; then
+              echo "Application is up!"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "Application failed to start"
+          docker compose logs app
+          exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM eclipse-temurin:17-jdk AS build
+
+WORKDIR /app
+
+COPY gradlew settings.gradle build.gradle ./
+COPY gradle/ gradle/
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon || true
+
+COPY src/ src/
+RUN ./gradlew clean build -x test --no-daemon
+
+FROM eclipse-temurin:17-jre
+
+WORKDIR /app
+
+COPY --from=build /app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  app:
+    build: .
+    container_name: qcheck-backend
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_PROFILES_ACTIVE: local
+      LOCAL_MYSQL_URL: jdbc:mysql://mysql:3306/qcheck
+      LOCAL_MYSQL_USER: ${MYSQL_USER}
+      LOCAL_MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
+      DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
+      DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
+      DISCORD_REDIRECT_URI: ${DISCORD_REDIRECT_URI}
+      JWT_SECRET: ${JWT_SECRET}
+    depends_on:
+      mysql:
+        condition: service_healthy
+    restart: unless-stopped
+
+  mysql:
+    image: mysql:8.0
+    container_name: qcheck-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: qcheck
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    ports:
+      - "3306:3306"
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
## Summary
- GitHub Actions self-hosted runner 기반 CI/CD 파이프라인 구축
- Docker Compose로 Spring Boot 앱 + MySQL 배포 환경 구성
- 멀티스테이지 Dockerfile로 빌드 최적화

## 변경 파일
- `.github/workflows/deploy.yml` — main 머지 시 self-hosted runner에서 자동 빌드/배포
- `Dockerfile` — 멀티스테이지 빌드 (JDK 17 빌드 → JRE 17 런타임)
- `docker-compose.yml` — App + MySQL 8.0 (healthcheck, 볼륨 영속화)
- `.env.example` — 환경변수 템플릿

## Test plan
- [ ] LXC에 self-hosted runner 설치 및 등록
- [ ] LXC에 Docker, Docker Compose 설치
- [ ] `.env` 파일 작성 (실제 환경변수)
- [ ] PR 머지 후 GitHub Actions 워크플로우 실행 확인
- [ ] `docker compose ps`로 컨테이너 정상 기동 확인
- [ ] `curl http://localhost:8080/swagger-ui.html` 응답 확인

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 환경 설정 템플릿 추가 (데이터베이스, 인증, 보안 설정)
  * 자동 배포 파이프라인 구성
  * 컨테이너 환경 구성 추가 (멀티스테이지 빌드, 헬스체크 포함)
  * 애플리케이션 및 데이터베이스 서비스 오케스트레이션 설정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->