### PR TITLE
Feat/structured logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,38 @@ JWT 타입 분리: access / refresh / signup 토큰은 클레임 `type` 으로 �
 - 권한 검증은 서비스 레이어에서 `ClubAuthorizationService.requireMembership` / `requireAdminOrOwner` 로.
 - 이메일·refresh token 등 민감 데이터는 응답 DTO 에 노출하지 않는다 (예: `UserSearchResultDto` 는 email 미포함).
 
+## Logging
+
+`logback-spring.xml` 에서 프로파일로 출력 포맷이 갈린다. `prod` = stdout JSON (Loki/Grafana 수집 전제), 그 외 = 사람이 읽기 쉬운 텍스트.
+
+**MDC 키** — 모든 로그 라인에 자동으로 박힘:
+- `requestId` — `RequestLoggingFilter` 가 요청 진입 시 발급. 클라이언트가 `X-Request-Id` 헤더로 보내면 그 값 사용, 아니면 UUID 생성. 응답 헤더에도 동일 값 내려감
+- `userId` — `JwtAuthInterceptor` 가 인증 성공 시 주입 (JWT 또는 dev-auth fallback 모두)
+- `clientIp` — `X-Forwarded-For` 우선, 없으면 `request.getRemoteAddr()`
+
+**메시지 컨벤션** — `도메인.이벤트 key=value key=value` 형태. 한국어 자유서술 X, grep 효율 우선.
+
+**현재 찍히는 로그** (도메인 이벤트 로깅은 미도입 — 인시던트 발생 시 해당 메서드에 추가):
+
+| 위치 | 메시지 | 레벨 | 트리거 |
+|---|---|---|---|
+| `RequestLoggingFilter` | `http.access method= path= status= latencyMs=` | INFO | 모든 요청, 응답 직후 |
+| `JwtAuthInterceptor` | `auth.dev_fallback used userId= path=` | WARN | dev-auth 헤더로 인증 성공 (프로덕션 오설정 감지용) |
+| `JwtAuthInterceptor` | `auth.dev_fallback invalid value=` | WARN | `X-USER-ID` 가 숫자가 아님 |
+| `JwtAuthInterceptor` | `auth.missing path=` | INFO | 인증 헤더 없음 |
+| `JwtAuthInterceptor` | `auth.rejected reason= path=` | INFO | JWT 검증 실패 (만료/타입 불일치/서명 실패) |
+| `GlobalExceptionHandler` | `app.exception code= msg=` | ERROR/WARN | `AppException` — 5xx ERROR + 스택, 4xx WARN |
+| `GlobalExceptionHandler` | `request.invalid type= msg=` | INFO | 입력 검증 실패류 (`MethodArgumentNotValidException` 등) |
+| `GlobalExceptionHandler` | `request.missing_header header= code=` | INFO | 필수 헤더 누락 |
+| `GlobalExceptionHandler` | `access.denied msg=` | WARN | `AccessDeniedException` |
+| `GlobalExceptionHandler` | `unhandled.exception type= msg=` | ERROR | catch-all (5xx) — 스택 포함 |
+| `DiscordOAuthService` | `discord.token_exchange status= latencyMs= [body=]` | INFO/WARN | Discord 토큰 교환 (200=INFO, 4xx/network=WARN) |
+| `DiscordOAuthService` | `discord.user_info status= latencyMs= [discordId=\|body=]` | INFO/WARN | Discord 사용자 정보 조회 |
+| Hibernate | 슬로우 쿼리 | WARN | 1초 초과 (`spring.jpa.properties.hibernate.session.events.log.LOG_QUERIES_SLOWER_THAN_MS=1000`) |
+| Hikari | 커넥션 누수 | WARN | 5초 동안 미반환 (`spring.datasource.hikari.leak-detection-threshold=5000`) |
+
+**민감 데이터 금지**: JWT 원문, refresh token, Discord client-secret, 비밀번호, 이메일은 절대 로그에 남기지 않음. 사용자 식별은 `userId`(Long) 만으로.
+
 ## Testing
 
 - 컨트롤러 테스트: `MockMvcBuilders.standaloneSetup(controller)` — Spring context 미로드.

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// 구조화된 JSON 로그 (Loki/Grafana 수집용)
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/team23/q_check/common/auth/JwtAuthInterceptor.java
+++ b/src/main/java/team23/q_check/common/auth/JwtAuthInterceptor.java
@@ -5,11 +5,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import team23.q_check.common.error.AppException;
 import team23.q_check.common.error.ErrorCode;
+import team23.q_check.common.log.RequestLoggingFilter;
 import team23.q_check.common.response.ApiResponse;
 
 import java.io.IOException;
@@ -43,7 +45,8 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
         try {
             String authHeader = request.getHeader("Authorization");
             if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                jwtService.extractAccessTokenUserId(authHeader.substring(7)); // access token만 허용
+                Long userId = jwtService.extractAccessTokenUserId(authHeader.substring(7)); // access token만 허용
+                MDC.put(RequestLoggingFilter.MDC_USER_ID, String.valueOf(userId));
                 return true;
             }
 
@@ -52,20 +55,25 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
                 String devHeader = request.getHeader("X-USER-ID");
                 if (devHeader != null && !devHeader.isBlank()) {
                     try {
-                        Long.parseLong(devHeader);
+                        Long userId = Long.parseLong(devHeader);
+                        MDC.put(RequestLoggingFilter.MDC_USER_ID, String.valueOf(userId));
+                        log.warn("auth.dev_fallback used userId={} path={} — 프로덕션이라면 dev-auth.enabled=false 확인 필요",
+                                userId, request.getRequestURI());
                         return true;
                     } catch (NumberFormatException e) {
-                        log.error("[DevAuth] X-USER-ID 파싱 실패: '{}'", devHeader);
+                        log.warn("auth.dev_fallback invalid value='{}'", devHeader);
                         writeError(response, ErrorCode.INVALID_REQUEST, "X-USER-ID must be a number");
                         return false;
                     }
                 }
             }
 
+            log.info("auth.missing path={}", request.getRequestURI());
             writeError(response, ErrorCode.UNAUTHORIZED, "로그인이 필요합니다");
             return false;
 
         } catch (AppException e) {
+            log.info("auth.rejected reason={} path={}", e.getMessage(), request.getRequestURI());
             writeError(response, e.getErrorCode(), e.getMessage());
             return false;
         }

--- a/src/main/java/team23/q_check/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/team23/q_check/common/error/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package team23.q_check.common.error;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -16,11 +18,19 @@ import java.nio.file.AccessDeniedException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
     @ExceptionHandler(AppException.class)
     public ResponseEntity<ApiResponse<Void>> handleAppException(AppException e) {
+        ErrorCode code = e.getErrorCode();
+        if (code.getHttpStatus().is5xxServerError()) {
+            log.error("app.exception code={} msg={}", code.getCode(), e.getMessage(), e);
+        } else {
+            log.warn("app.exception code={} msg={}", code.getCode(), e.getMessage());
+        }
         return ResponseEntity
-                .status(e.getErrorCode().getHttpStatus())
-                .body(ApiResponse.error(e.getErrorCode(), e.getMessage()));
+                .status(code.getHttpStatus())
+                .body(ApiResponse.error(code, e.getMessage()));
     }
 
     @ExceptionHandler({
@@ -31,6 +41,7 @@ public class GlobalExceptionHandler {
             IllegalArgumentException.class
     })
     public ResponseEntity<ApiResponse<Void>> handleInvalidRequest(Exception e) {
+        log.info("request.invalid type={} msg={}", e.getClass().getSimpleName(), e.getMessage());
         return ResponseEntity
                 .status(ErrorCode.INVALID_REQUEST.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.INVALID_REQUEST, e.getMessage()));
@@ -45,6 +56,7 @@ public class GlobalExceptionHandler {
         ErrorCode errorCode = HttpHeaders.AUTHORIZATION.equalsIgnoreCase(e.getHeaderName())
                 ? ErrorCode.UNAUTHORIZED
                 : ErrorCode.INVALID_REQUEST;
+        log.info("request.missing_header header={} code={}", e.getHeaderName(), errorCode.getCode());
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ApiResponse.error(errorCode, e.getMessage()));
@@ -52,6 +64,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ApiResponse<Void>> handleAccessDenied(AccessDeniedException e) {
+        log.warn("access.denied msg={}", e.getMessage());
         return ResponseEntity
                 .status(ErrorCode.FORBIDDEN.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.FORBIDDEN, e.getMessage()));
@@ -59,6 +72,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("unhandled.exception type={} msg={}", e.getClass().getName(), e.getMessage(), e);
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_ERROR.getHttpStatus())
                 .body(ApiResponse.error(ErrorCode.INTERNAL_ERROR, e.getMessage()));

--- a/src/main/java/team23/q_check/common/log/RequestLoggingFilter.java
+++ b/src/main/java/team23/q_check/common/log/RequestLoggingFilter.java
@@ -1,0 +1,70 @@
+package team23.q_check.common.log;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * 모든 요청에 대해 requestId·clientIp·userId(인증 후 주입됨)를 MDC에 넣고,
+ * 응답 직후 액세스 로그 1줄을 INFO로 남긴다. Loki에서 한 요청을 끝까지 추적하는 키가 된다.
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger("access");
+
+    public static final String MDC_REQUEST_ID = "requestId";
+    public static final String MDC_CLIENT_IP = "clientIp";
+    public static final String MDC_USER_ID = "userId";
+
+    private static final String HEADER_REQUEST_ID = "X-Request-Id";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        long startNanos = System.nanoTime();
+        String requestId = resolveRequestId(request);
+        MDC.put(MDC_REQUEST_ID, requestId);
+        MDC.put(MDC_CLIENT_IP, resolveClientIp(request));
+        response.setHeader(HEADER_REQUEST_ID, requestId);
+
+        try {
+            chain.doFilter(request, response);
+        } finally {
+            long latencyMs = (System.nanoTime() - startNanos) / 1_000_000;
+            log.info("http.access method={} path={} status={} latencyMs={}",
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    response.getStatus(),
+                    latencyMs);
+            MDC.clear();
+        }
+    }
+
+    private String resolveRequestId(HttpServletRequest request) {
+        String incoming = request.getHeader(HEADER_REQUEST_ID);
+        return (incoming != null && !incoming.isBlank()) ? incoming : UUID.randomUUID().toString();
+    }
+
+    private String resolveClientIp(HttpServletRequest request) {
+        String xff = request.getHeader("X-Forwarded-For");
+        if (xff != null && !xff.isBlank()) {
+            int comma = xff.indexOf(',');
+            return (comma > 0 ? xff.substring(0, comma) : xff).trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/team23/q_check/identity/domain/service/DiscordOAuthService.java
+++ b/src/main/java/team23/q_check/identity/domain/service/DiscordOAuthService.java
@@ -1,12 +1,15 @@
 package team23.q_check.identity.domain.service;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestClientResponseException;
 import org.springframework.web.util.UriComponentsBuilder;
 import team23.q_check.common.config.DiscordProperties;
 import team23.q_check.common.error.AppException;
@@ -14,6 +17,8 @@ import team23.q_check.common.error.ErrorCode;
 
 @Service
 public class DiscordOAuthService {
+
+    private static final Logger log = LoggerFactory.getLogger(DiscordOAuthService.class);
 
     private final RestClient restClient;
     private final DiscordProperties discordProps;
@@ -42,28 +47,51 @@ public class DiscordOAuthService {
         body.add("code", code);
         body.add("redirect_uri", discordProps.redirectUri());
 
+        long startNanos = System.nanoTime();
         try {
-            return restClient.post()
+            DiscordTokenResponse response = restClient.post()
                     .uri(discordProps.tokenUrl())
                     .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                     .body(body)
                     .retrieve()
                     .body(DiscordTokenResponse.class);
+            log.info("discord.token_exchange status=200 latencyMs={}", elapsedMs(startNanos));
+            return response;
+        } catch (RestClientResponseException e) {
+            log.warn("discord.token_exchange status={} latencyMs={} body={}",
+                    e.getStatusCode().value(), elapsedMs(startNanos), e.getResponseBodyAsString());
+            throw new AppException(ErrorCode.UNAUTHORIZED, "Discord 인가코드 교환에 실패했습니다");
         } catch (RestClientException e) {
+            log.warn("discord.token_exchange status=network_error latencyMs={} msg={}",
+                    elapsedMs(startNanos), e.getMessage());
             throw new AppException(ErrorCode.UNAUTHORIZED, "Discord 인가코드 교환에 실패했습니다");
         }
     }
 
     public DiscordUserInfo getUserInfo(String discordAccessToken) {
+        long startNanos = System.nanoTime();
         try {
-            return restClient.get()
+            DiscordUserInfo info = restClient.get()
                     .uri(discordProps.userUrl())
                     .header("Authorization", "Bearer " + discordAccessToken)
                     .retrieve()
                     .body(DiscordUserInfo.class);
+            log.info("discord.user_info status=200 latencyMs={} discordId={}",
+                    elapsedMs(startNanos), info != null ? info.id() : null);
+            return info;
+        } catch (RestClientResponseException e) {
+            log.warn("discord.user_info status={} latencyMs={} body={}",
+                    e.getStatusCode().value(), elapsedMs(startNanos), e.getResponseBodyAsString());
+            throw new AppException(ErrorCode.INTERNAL_ERROR, "Discord 사용자 정보 조회에 실패했습니다");
         } catch (RestClientException e) {
+            log.warn("discord.user_info status=network_error latencyMs={} msg={}",
+                    elapsedMs(startNanos), e.getMessage());
             throw new AppException(ErrorCode.INTERNAL_ERROR, "Discord 사용자 정보 조회에 실패했습니다");
         }
+    }
+
+    private long elapsedMs(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000;
     }
 
     public record DiscordTokenResponse(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,13 @@ spring:
     hibernate:
       # 데이터베이스의 스키마와 jpa 엔티티가 불일치할때 애플리케이션 실행 중단
       ddl-auto: validate
+    properties:
+      hibernate:
+        # 1초 넘는 쿼리는 WARN으로 남겨 슬로우 쿼리 추적
+        session:
+          events:
+            log:
+              LOG_QUERIES_SLOWER_THAN_MS: 1000
 
   flyway:
     enabled: true
@@ -19,6 +26,8 @@ spring:
       connectionTimeout: '30000'
       maximum-pool-size: '10'
       max-lifetime: '1800000'
+      # 5초 동안 반환 안 된 커넥션은 WARN — 트랜잭션 누수 즉시 감지
+      leak-detection-threshold: '5000'
     url: ${LOCAL_MYSQL_URL}               # ex) jdbc:mysql://localhost:3306/qcheck
     username: ${LOCAL_MYSQL_USER}         # MySQL 사용자명
     password: ${LOCAL_MYSQL_PASSWORD}     # MySQL 비밀번호

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <!-- prod 프로파일: stdout으로 JSON 한 줄씩 출력. Promtail/Grafana Agent가 수집해 Loki로 보낸다. -->
+    <springProfile name="prod">
+        <appender name="STDOUT_JSON" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <includeMdcKeyName>requestId</includeMdcKeyName>
+                <includeMdcKeyName>userId</includeMdcKeyName>
+                <includeMdcKeyName>clientIp</includeMdcKeyName>
+                <fieldNames>
+                    <timestamp>ts</timestamp>
+                    <message>msg</message>
+                    <logger>logger</logger>
+                    <thread>thread</thread>
+                    <levelValue>[ignore]</levelValue>
+                    <version>[ignore]</version>
+                </fieldNames>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="STDOUT_JSON"/>
+        </root>
+        <logger name="team23.q_check" level="INFO"/>
+        <logger name="org.hibernate.SQL" level="WARN"/>
+    </springProfile>
+
+    <!-- prod가 아닌 모든 환경(local, test, 미설정 등): 사람이 읽기 쉬운 텍스트 -->
+    <springProfile name="!prod">
+        <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} %-5level [%X{requestId:-}] [u=%X{userId:-}] %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+
+        <root level="INFO">
+            <appender-ref ref="STDOUT"/>
+        </root>
+        <logger name="team23.q_check" level="DEBUG"/>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

- `logback-spring.xml` 추가: `prod` 프로파일은 stdout으로 JSON, 그 외는 사람이 읽기 쉬운 텍스트로 분기. Loki/Grafana 수집 전제                                                                               
- `RequestLoggingFilter` 신설: `requestId`(없으면 UUID 생성)·`clientIp`를 MDC에 주입하고 응답 후 `method/path/status/latencyMs` 한 줄을 액세스 로그로 남김. 응답 헤더 `X-Request-Id`도 함께 내려줌
- `JwtAuthInterceptor`: 인증 성공 시 `userId`를 MDC에 주입, 실패는 사유별로 분기 로깅. `dev-auth` fallback 사용은 WARN으로 띄워 프로덕션 오설정 즉시 감지                                                    
- `GlobalExceptionHandler`: 5xx는 ERROR + 스택, 4xx는 WARN, 입력 검증류는 INFO. 지금까지 5xx가 응답 본문 외 흔적이 없던 문제 해결                                                                            
- `application.yml`: Hibernate 슬로우 쿼리 임계값 1초, Hikari `leak-detection-threshold` 5초 설정                                                                                                            
- `DiscordOAuthService`: 토큰 교환·사용자 정보 조회를 200/4xx/network_error로 구분해 latency까지 로깅. 외부 장애와 내부 장애 분리   

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [x] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 🔌 API 변경 사항 (해당 시)

<!-- API 변경이 있는 경우 작성해주세요. -->

| Method | Endpoint | 변경 내용 |
|--------|----------|-----------|
|        |          |           |

### Breaking Change
- [ ] ⚠️ Breaking Change 있음 (기존 API 변경)
- [x] ✅ Breaking Change 없음

---

## 🧪 테스트

### 체크리스트

- [x] `./gradlew build` 성공
- [x] `./gradlew test` 통과
- [ ] 로컬에서 API 테스트 완료
- [ ] Postman/Swagger로 동작 확인

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->
  ```bash
  # 1. 로컬 실행 (기본 프로파일 = 텍스트 로그)
  ./gradlew bootRun                                                                                                                                                                                            
   
  # 2. 인증 없이 호출 → 액세스 로그 1줄 + auth.missing INFO 로그 + 401 확인                                                                                                                                    
  curl -i http://localhost:8080/api/clubs/my                                                                                                                                                                   
   
  # 3. 응답 헤더에 X-Request-Id 가 박혀 있는지 확인                                                                                                                                                            
  # 4. 동일 요청 ID로 서버 로그 grep — MDC 값(requestId, userId)이 한 줄에 모두 박히는지 확인                                                                                                                  
                                                                                                                                                                                                               
  # 5. JSON 출력 검증 (Loki 연동 전제)                                                                                                                                                                         
  SPRING_PROFILES_ACTIVE=prod ./gradlew bootRun                                                                                                                                                                
  # stdout이 JSON 한 줄씩 떨어지는지 확인  
```

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->
- 도메인 상태 전이 로깅(체크인/정산 상태/클럽 권한 변경 등)은 일부러 보류. 트래픽 규모상 미리 깔면 노이즈가 더 큼. 실제 인시던트 발생 시 해당 메서드만 골라 추가하는 방향으로 합의됨
- prod 프로파일을 새로 도입한 것이라 배포 시 SPRING_PROFILES_ACTIVE=prod 설정 필요. 미설정이면 텍스트 포맷으로 폴백                                                                                          
- 민감 데이터(JWT 원문, refresh token, Discord client-secret, 비밀번호)는 절대 로그에 남지 않게 처리. PII는 userId(Long)만으로 추적 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 요청 추적 ID 기반의 접근 로깅 기능 추가
  * 프로덕션 환경용 구조화된 JSON 로깅 지원

* **개선사항**
  * 데이터베이스 연결 누수 감지 기능 추가 (5초 초과 시 경고)
  * 느린 쿼리 자동 감지 및 로깅 (1초 이상)
  * 오류 추적 및 진단 기능 강화

* **Chores**
  * 로깅 라이브러리 의존성 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->