### PR TITLE
feat/#28: Actuator metrics 및 Promtail 로그 수집 설정 (#28)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,10 +47,10 @@ jobs:
         run: ./gradlew clean build -x test --no-daemon
 
       - name: Stop existing containers
-        run: docker compose down || true
+        run: docker compose -f docker-compose.yml -f docker-compose.monitoring.yml down || true
 
       - name: Build and start containers
-        run: docker compose up -d --build
+        run: docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up -d --build
 
       - name: Health check
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
 
 	// 구조화된 JSON 로그 (Loki/Grafana 수집용)
 	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+
+	// Monitoring: Actuator + Prometheus metrics
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,10 @@
+services:
+  promtail:
+    image: grafana/promtail:3.0.0
+    container_name: qcheck-promtail
+    volumes:
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./monitoring/promtail-config.yml:/etc/promtail/config.yml
+    command: -config.file=/etc/promtail/config.yml
+    restart: unless-stopped

--- a/monitoring/promtail-config.yml
+++ b/monitoring/promtail-config.yml
@@ -1,0 +1,26 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://192.168.1.12:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      # container_name 라벨 추가
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: container_name
+      # qcheck 컨테이너만 수집
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(qcheck-.*)'
+        action: keep
+    pipeline_stages:
+      - docker: {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,15 @@ spring:
     password: ${LOCAL_MYSQL_PASSWORD}     # MySQL 비밀번호
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus,info
+  metrics:
+    tags:
+      application: qcheck
+
 dev-auth:
   enabled: true  # X-USER-ID 헤더 인증 허용 여부. 로컬 개발 전용, 프로덕션에서는 반드시 false
 


### PR DESCRIPTION
## Summary
- Spring Boot Actuator + Micrometer Prometheus 의존성 추가 (`/actuator/health`, `/actuator/prometheus` 노출)
- Promtail docker-compose overlay로 컨테이너 로그를 Loki(192.168.1.12)로 전송
- Prometheus(192.168.1.20), Loki(192.168.1.12), Grafana(192.168.1.21) 설정 파일은 프로젝트 루트 `monitoring/`에 별도 관리

## 인프라 구성
| 서비스 | IP | 비고 |
|--------|-----|------|
| Grafana | 192.168.1.21 | 기존 LXC |
| Prometheus | 192.168.1.20 | 기존 LXC |
| Loki | 192.168.1.12 | 신규 LXC |
| 백엔드 + Promtail | 192.168.1.30 | 기존 LXC |

## Test plan
- [ ] `curl localhost:8080/actuator/health` → `{"status":"UP"}`
- [ ] `curl localhost:8080/actuator/prometheus` → metrics 출력
- [ ] Loki LXC(192.168.1.12)에서 `docker compose up -d` → `curl :3100/ready`
- [ ] 백엔드에서 `docker compose -f docker-compose.yml -f docker-compose.monitoring.yml up --build`
- [ ] Grafana에서 Loki 데이터소스 추가 → `{container_name="qcheck-backend"}` 로그 확인

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 애플리케이션 모니터링 및 메트릭 수집 기능 추가
* Prometheus 호환 메트릭 엔드포인트 제공
* 애플리케이션 헬스 체크 및 시스템 정보 엔드포인트 공개
* 로그 및 메트릭 시각화를 위한 모니터링 인프라 구성

<!-- end of auto-generated comment: release notes by coderabbit.ai -->