### PR TITLE
refactor(auth): 인증 엔드포인트를 /api/auth/** 로 이동

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ LOCAL_MYSQL_PASSWORD=<password>
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 DISCORD_CLIENT_ID=<id>
 DISCORD_CLIENT_SECRET=<secret>
-DISCORD_REDIRECT_URI=http://localhost:8080/auth/code
+DISCORD_REDIRECT_URI=http://localhost:8080/api/auth/code
 JWT_SECRET=<at-least-32-chars>
 ```
 
@@ -37,7 +37,7 @@ Swagger UI is served at `/swagger-ui.html`.
 **Stack:** Spring Boot 3.4.2 · Spring Data JPA · MySQL · Flyway · Lombok · SpringDoc OpenAPI 2.8.5 · JJWT 0.12 · JUnit 5 + Mockito
 
 **Domain modules** under `src/main/java/team23/q_check/`:
-- `identity` — Discord OAuth2 인증, 사용자 정보·검색 (`/auth/**`, `/api/users/**`)
+- `identity` — Discord OAuth2 인증, 사용자 정보·검색 (`/api/auth/**`, `/api/users/**`)
 - `club` — 클럽 생성·멤버 관리·권한 위임·탈퇴/제거 (`/api/clubs/**`)
 - `event` — 행사 CRUD·신청 폼·참가 신청/취소·QR/수동 출석·캘린더·사진 (`/api/events/**`, `/api/attendance/**`, `/api/calendar/**`)
 - `settlement` — 정산 그룹 분배·상태 전이(UNPAID/PENDING/COMPLETED)·리마인드 (`/api/settlements/**`)
@@ -52,12 +52,12 @@ Each module follows the pattern: `controller/`, `dto/`, `domain/{model,repositor
 **Discord OAuth2 + JWT** 가 기본 인증 흐름. 헤더 기반 dev fallback 도 지원.
 
 흐름:
-1. `GET /auth/login` → Discord OAuth 인가 페이지로 redirect, state 를 세션 저장
-2. Discord 콜백 → `GET /auth/code?code=...&state=...`
+1. `GET /api/auth/login` → Discord OAuth 인가 페이지로 redirect, state 를 세션 저장
+2. Discord 콜백 → `GET /api/auth/code?code=...&state=...`
    - 기존 회원: access JWT 반환 + `refresh_token` httpOnly 쿠키
    - 신규 회원: 10분짜리 signup JWT 반환 (쿠키 없음)
-3. `POST /auth/signup` (Authorization: Bearer signup-jwt) → 회원 생성 후 access JWT + refresh 쿠키
-4. `POST /auth/refresh` (refresh_token 쿠키) → 새 access·refresh 쌍 (refresh 회전)
+3. `POST /api/auth/signup` (Authorization: Bearer signup-jwt) → 회원 생성 후 access JWT + refresh 쿠키
+4. `POST /api/auth/refresh` (refresh_token 쿠키) → 새 access·refresh 쌍 (refresh 회전)
 
 보호된 엔드포인트는 `JwtAuthInterceptor` 가 게이트하고, `@CurrentUserId` 가 컨트롤러 파라미터로 userId 를 주입한다.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ LOCAL_MYSQL_PASSWORD=<password>
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 DISCORD_CLIENT_ID=<id>
 DISCORD_CLIENT_SECRET=<secret>
-DISCORD_REDIRECT_URI=http://localhost:8080/auth/code
+DISCORD_REDIRECT_URI=http://localhost:8080/api/auth/code
 JWT_SECRET=<at-least-32-chars>
 ```
 
@@ -51,7 +51,7 @@ API 문서는 `http://localhost:8080/swagger-ui.html` 에서 확인.
 
 | 경로 | 설명 |
 |---|---|
-| `/auth/**` | Discord 로그인, 회원가입, 토큰 갱신 |
+| `/api/auth/**` | Discord 로그인, 회원가입, 토큰 갱신 |
 | `/api/users/**` | 내 정보, 사용자 검색 |
 | `/api/clubs/**` | 동아리·멤버 관리 |
 | `/api/events/**` | 행사 CRUD, 신청, 사진 |

--- a/src/main/java/team23/q_check/common/config/WebMvcConfig.java
+++ b/src/main/java/team23/q_check/common/config/WebMvcConfig.java
@@ -40,7 +40,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addInterceptor(jwtAuthInterceptor)
                 .addPathPatterns("/**")
                 .excludePathPatterns(
-                        "/auth/**",
+                        "/api/auth/**",
                         "/swagger-ui.html",
                         "/swagger-ui/**",
                         "/v3/api-docs/**"

--- a/src/main/java/team23/q_check/identity/controller/AuthController.java
+++ b/src/main/java/team23/q_check/identity/controller/AuthController.java
@@ -25,7 +25,7 @@ import java.time.Duration;
 
 @Tag(name = "Auth", description = "Discord OAuth2 인증 API")
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 public class AuthController {
 
     private static final String OAUTH_STATE_SESSION_KEY = "oauth2_state";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,7 +42,7 @@ cors:
 discord:
   client-id: ${DISCORD_CLIENT_ID}         # Discord 애플리케이션 Client ID
   client-secret: ${DISCORD_CLIENT_SECRET} # Discord 애플리케이션 Client Secret
-  redirect-uri: ${DISCORD_REDIRECT_URI}   # ex) http://localhost:8080/auth/code (Discord 앱에 등록 필요)
+  redirect-uri: ${DISCORD_REDIRECT_URI}   # ex) http://localhost:8080/api/auth/code (Discord 앱에 등록 필요)
   oauth-url: https://discord.com/oauth2/authorize
   token-url: https://discord.com/api/oauth2/token
   user-url: https://discord.com/api/users/@me

--- a/src/test/java/team23/q_check/identity/controller/AuthControllerTest.java
+++ b/src/test/java/team23/q_check/identity/controller/AuthControllerTest.java
@@ -46,7 +46,7 @@ class AuthControllerTest {
     void login_redirectsToDiscordAndStoresStateInSession() throws Exception {
         when(authService.getAuthorizationUrl(any())).thenReturn("https://discord.com/oauth2/authorize?...");
 
-        var result = mockMvc.perform(get("/auth/login"))
+        var result = mockMvc.perform(get("/api/auth/login"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl("https://discord.com/oauth2/authorize?..."))
                 .andReturn();
@@ -63,7 +63,7 @@ class AuthControllerTest {
         when(authService.processCode("auth-code"))
                 .thenReturn(new CodeResult(false, "access-token", "refresh-token"));
 
-        mockMvc.perform(get("/auth/code")
+        mockMvc.perform(get("/api/auth/code")
                         .session(session)
                         .param("code", "auth-code")
                         .param("state", "state-1"))
@@ -82,7 +82,7 @@ class AuthControllerTest {
         when(authService.processCode("auth-code"))
                 .thenReturn(new CodeResult(true, "signup-token", null));
 
-        mockMvc.perform(get("/auth/code")
+        mockMvc.perform(get("/api/auth/code")
                         .session(session)
                         .param("code", "auth-code")
                         .param("state", "state-1"))
@@ -97,7 +97,7 @@ class AuthControllerTest {
         MockHttpSession session = new MockHttpSession();
         session.setAttribute(OAUTH_STATE_SESSION_KEY, "expected-state");
 
-        mockMvc.perform(get("/auth/code")
+        mockMvc.perform(get("/api/auth/code")
                         .session(session)
                         .param("code", "auth-code")
                         .param("state", "different-state"))
@@ -107,7 +107,7 @@ class AuthControllerTest {
 
     @Test
     void handleCode_noSessionState_returnsBadRequest() throws Exception {
-        mockMvc.perform(get("/auth/code")
+        mockMvc.perform(get("/api/auth/code")
                         .param("code", "auth-code")
                         .param("state", "state-1"))
                 .andExpect(status().isBadRequest())
@@ -118,7 +118,7 @@ class AuthControllerTest {
     void checkNickname_returnsAvailability() throws Exception {
         when(authService.isNicknameAvailable("free-nick")).thenReturn(true);
 
-        mockMvc.perform(get("/auth/nickname/check").param("nickname", "free-nick"))
+        mockMvc.perform(get("/api/auth/nickname/check").param("nickname", "free-nick"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.available").value(true));
     }
@@ -128,7 +128,7 @@ class AuthControllerTest {
         when(authService.signup(any(), any()))
                 .thenReturn(new TokenResult(7L, "access-token", "refresh-token"));
 
-        mockMvc.perform(post("/auth/signup")
+        mockMvc.perform(post("/api/auth/signup")
                         .header("Authorization", "Bearer signup-token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -142,7 +142,7 @@ class AuthControllerTest {
 
     @Test
     void signup_missingAuthorizationHeader_returnsUnauthorized() throws Exception {
-        mockMvc.perform(post("/auth/signup")
+        mockMvc.perform(post("/api/auth/signup")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 { "name": "김지윤", "nickname": "kimjyun", "email": "kim@example.com" }
@@ -153,7 +153,7 @@ class AuthControllerTest {
 
     @Test
     void signup_malformedAuthorizationHeader_returnsUnauthorized() throws Exception {
-        mockMvc.perform(post("/auth/signup")
+        mockMvc.perform(post("/api/auth/signup")
                         .header("Authorization", "signup-token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -167,7 +167,7 @@ class AuthControllerTest {
         when(authService.refresh("old-refresh"))
                 .thenReturn(new TokenResult(7L, "new-access", "new-refresh"));
 
-        mockMvc.perform(post("/auth/refresh")
+        mockMvc.perform(post("/api/auth/refresh")
                         .cookie(new jakarta.servlet.http.Cookie("refresh_token", "old-refresh")))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.userId").value(7))


### PR DESCRIPTION
배포 환경의 리버스 프록시가 /api/* 만 백엔드로 라우팅하기 때문에
기존 /auth/** 경로는 도달이 불가능했다. AuthController 매핑과
JwtAuthInterceptor 제외 패턴, 테스트, 문서, DISCORD_REDIRECT_URI 예시를 모두 /api/auth/** 기준으로 일치시킨다.

⚠️ 배포 시 함께 갱신 필요:
- GitHub Secret DISCORD_REDIRECT_URI → https://qcheck.asia/api/auth/code
- Discord 개발자 포털 OAuth2 Redirects 등록값

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * 인증 API 엔드포인트의 경로를 `/auth/**`에서 `/api/auth/**`로 통일했습니다. Discord OAuth 리다이렉트 URI, 환경 설정, 테스트 케이스 및 문서가 함께 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->