### PR TITLE
refactor(docs): Swagger UI와 OpenAPI 경로를 /api 아래로 이동

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ DISCORD_REDIRECT_URI=http://localhost:8080/api/auth/code
 JWT_SECRET=<at-least-32-chars>
 ```
 
-Swagger UI is served at `/swagger-ui.html`.
+Swagger UI is served at `/api/swagger-ui.html` (OpenAPI JSON: `/api/v3/api-docs`).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ JWT_SECRET=<at-least-32-chars>
 ./gradlew bootRun
 ```
 
-API 문서는 `http://localhost:8080/swagger-ui.html` 에서 확인.
+API 문서는 `http://localhost:8080/api/swagger-ui.html` 에서 확인.
 
 ### 테스트
 

--- a/src/main/java/team23/q_check/common/config/WebMvcConfig.java
+++ b/src/main/java/team23/q_check/common/config/WebMvcConfig.java
@@ -41,9 +41,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .addPathPatterns("/**")
                 .excludePathPatterns(
                         "/api/auth/**",
-                        "/swagger-ui.html",
-                        "/swagger-ui/**",
-                        "/v3/api-docs/**"
+                        "/api/swagger-ui.html",
+                        "/api/swagger-ui/**",
+                        "/api/v3/api-docs/**"
                 );
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=q-check
-springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.path=/api/swagger-ui.html
+springdoc.api-docs.path=/api/v3/api-docs


### PR DESCRIPTION
프록시가 /api/* 만 라우팅하므로 기존 /swagger-ui.html, /v3/api-docs 도 외부에서 접근 불가였다. springdoc 경로 두 개와 인터셉터 제외 패턴,
README 안내를 /api 기준으로 일치시킨다.
- Swagger UI: /api/swagger-ui.html
- OpenAPI JSON: /api/v3/api-docs