### PR TITLE
fix: 캘린더 검색/필터 스코프를 소속 클럽 전체 이벤트로 확장

### DIFF
--- a/src/main/java/team23/q_check/event/domain/repository/EventRepository.java
+++ b/src/main/java/team23/q_check/event/domain/repository/EventRepository.java
@@ -21,27 +21,27 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Query("""
             SELECT e FROM Event e
-            WHERE e.id IN :eventIds
+            WHERE e.club.id IN :clubIds
             AND (LOWER(e.title) LIKE LOWER(CONCAT('%', :query, '%'))
                  OR LOWER(COALESCE(e.location, '')) LIKE LOWER(CONCAT('%', :query, '%'))
                  OR LOWER(e.club.name) LIKE LOWER(CONCAT('%', :query, '%')))
             ORDER BY e.startTime ASC
             """)
-    List<Event> searchInUserEvents(@Param("eventIds") List<Long> eventIds,
-                                   @Param("query") String query);
+    List<Event> searchInUserClubs(@Param("clubIds") List<Long> clubIds,
+                                  @Param("query") String query);
 
     @Query("""
             SELECT e FROM Event e
-            WHERE e.id IN :eventIds
+            WHERE e.club.id IN :clubIds
             AND (:startDate IS NULL OR e.startTime >= :startDate)
             AND (:endDate IS NULL OR e.startTime <= :endDate)
             AND (:eventName IS NULL OR LOWER(e.title) LIKE LOWER(CONCAT('%', :eventName, '%')))
             AND (:clubName IS NULL OR LOWER(e.club.name) LIKE LOWER(CONCAT('%', :clubName, '%')))
             ORDER BY e.startTime ASC
             """)
-    List<Event> filterUserEvents(@Param("eventIds") List<Long> eventIds,
-                                 @Param("startDate") LocalDateTime startDate,
-                                 @Param("endDate") LocalDateTime endDate,
-                                 @Param("eventName") String eventName,
-                                 @Param("clubName") String clubName);
+    List<Event> filterUserClubEvents(@Param("clubIds") List<Long> clubIds,
+                                     @Param("startDate") LocalDateTime startDate,
+                                     @Param("endDate") LocalDateTime endDate,
+                                     @Param("eventName") String eventName,
+                                     @Param("clubName") String clubName);
 }

--- a/src/main/java/team23/q_check/event/domain/service/CalendarService.java
+++ b/src/main/java/team23/q_check/event/domain/service/CalendarService.java
@@ -8,9 +8,7 @@ import team23.q_check.club.domain.repository.ClubMemberRepository;
 import team23.q_check.common.error.AppException;
 import team23.q_check.common.error.ErrorCode;
 import team23.q_check.event.domain.model.Event;
-import team23.q_check.event.domain.model.RegistrationStatus;
 import team23.q_check.event.domain.repository.EventRepository;
-import team23.q_check.event.domain.repository.RegistrationRepository;
 import team23.q_check.event.dto.CalendarClubGroupDto;
 import team23.q_check.event.dto.CalendarEventItemDto;
 
@@ -24,21 +22,15 @@ import java.util.stream.Collectors;
 @Service
 public class CalendarService {
 
-    private static final List<RegistrationStatus> ACTIVE_STATUSES =
-            List.of(RegistrationStatus.REGISTERED, RegistrationStatus.CHECKED_IN);
-
     private final ClubMemberRepository clubMemberRepository;
     private final EventRepository eventRepository;
-    private final RegistrationRepository registrationRepository;
 
     public CalendarService(
             ClubMemberRepository clubMemberRepository,
-            EventRepository eventRepository,
-            RegistrationRepository registrationRepository
+            EventRepository eventRepository
     ) {
         this.clubMemberRepository = clubMemberRepository;
         this.eventRepository = eventRepository;
-        this.registrationRepository = registrationRepository;
     }
 
     @Transactional(readOnly = true)
@@ -83,12 +75,12 @@ public class CalendarService {
             throw new AppException(ErrorCode.INVALID_REQUEST, "query is required");
         }
 
-        List<Long> eventIds = registrationRepository.findEventIdsByUserIdAndStatuses(userId, ACTIVE_STATUSES);
-        if (eventIds.isEmpty()) {
+        List<Long> clubIds = userClubIds(userId);
+        if (clubIds.isEmpty()) {
             return Collections.emptyList();
         }
 
-        return eventRepository.searchInUserEvents(eventIds, query.trim()).stream()
+        return eventRepository.searchInUserClubs(clubIds, query.trim()).stream()
                 .map(this::toEventItemDto)
                 .toList();
     }
@@ -105,18 +97,24 @@ public class CalendarService {
             throw new AppException(ErrorCode.INVALID_REQUEST, "startDate must not be after endDate");
         }
 
-        List<Long> eventIds = registrationRepository.findEventIdsByUserIdAndStatuses(userId, ACTIVE_STATUSES);
-        if (eventIds.isEmpty()) {
+        List<Long> clubIds = userClubIds(userId);
+        if (clubIds.isEmpty()) {
             return Collections.emptyList();
         }
 
-        return eventRepository.filterUserEvents(
-                eventIds,
+        return eventRepository.filterUserClubEvents(
+                clubIds,
                 startDate,
                 endDate,
                 isBlank(eventName) ? null : eventName.trim(),
                 isBlank(clubName) ? null : clubName.trim()
         ).stream().map(this::toEventItemDto).toList();
+    }
+
+    private List<Long> userClubIds(Long userId) {
+        return clubMemberRepository.findAllByUser_Id(userId).stream()
+                .map(m -> m.getClub().getId())
+                .toList();
     }
 
     private CalendarEventItemDto toEventItemDto(Event event) {

--- a/src/test/java/team23/q_check/event/service/CalendarServiceTest.java
+++ b/src/test/java/team23/q_check/event/service/CalendarServiceTest.java
@@ -10,7 +10,6 @@ import team23.q_check.common.error.AppException;
 import team23.q_check.common.error.ErrorCode;
 import team23.q_check.event.domain.model.Event;
 import team23.q_check.event.domain.repository.EventRepository;
-import team23.q_check.event.domain.repository.RegistrationRepository;
 import team23.q_check.event.domain.service.CalendarService;
 import team23.q_check.event.dto.CalendarClubGroupDto;
 import team23.q_check.event.dto.CalendarEventItemDto;
@@ -23,7 +22,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -33,15 +31,13 @@ class CalendarServiceTest {
 
     private ClubMemberRepository clubMemberRepository;
     private EventRepository eventRepository;
-    private RegistrationRepository registrationRepository;
     private CalendarService calendarService;
 
     @BeforeEach
     void setUp() {
         clubMemberRepository = mock(ClubMemberRepository.class);
         eventRepository = mock(EventRepository.class);
-        registrationRepository = mock(RegistrationRepository.class);
-        calendarService = new CalendarService(clubMemberRepository, eventRepository, registrationRepository);
+        calendarService = new CalendarService(clubMemberRepository, eventRepository);
     }
 
     @Test
@@ -128,9 +124,8 @@ class CalendarServiceTest {
     }
 
     @Test
-    void searchEvents_noActiveRegistrations_returnsEmpty() {
-        when(registrationRepository.findEventIdsByUserIdAndStatuses(eq(1L), anyList()))
-                .thenReturn(List.of());
+    void searchEvents_userWithoutClubs_returnsEmpty() {
+        when(clubMemberRepository.findAllByUser_Id(1L)).thenReturn(List.of());
 
         assertTrue(calendarService.searchEvents(1L, "OT").isEmpty());
     }
@@ -138,10 +133,12 @@ class CalendarServiceTest {
     @Test
     void searchEvents_returnsRepositoryHitsAsDto() throws Exception {
         Club umc = newClub(10L, "UMC");
+        User me = new User("dev-1", null, "kim", null);
+        setId(me, 1L);
         Event ot = newEvent(101L, umc, "OT", "2026-03-10T19:00:00");
-        when(registrationRepository.findEventIdsByUserIdAndStatuses(eq(1L), anyList()))
-                .thenReturn(List.of(101L));
-        when(eventRepository.searchInUserEvents(List.of(101L), "OT")).thenReturn(List.of(ot));
+        when(clubMemberRepository.findAllByUser_Id(1L))
+                .thenReturn(List.of(new ClubMember(umc, me, ClubRole.MEMBER)));
+        when(eventRepository.searchInUserClubs(List.of(10L), "OT")).thenReturn(List.of(ot));
 
         List<CalendarEventItemDto> result = calendarService.searchEvents(1L, "  OT  ");
 
@@ -151,13 +148,15 @@ class CalendarServiceTest {
     }
 
     @Test
-    void filterEvents_allFiltersBlank_returnsAllUserEvents() throws Exception {
+    void filterEvents_allFiltersBlank_returnsAllUserClubEvents() throws Exception {
         Club umc = newClub(10L, "UMC");
+        User me = new User("dev-1", null, "kim", null);
+        setId(me, 1L);
         Event ot = newEvent(101L, umc, "OT", "2026-03-10T19:00:00");
-        when(registrationRepository.findEventIdsByUserIdAndStatuses(eq(1L), anyList()))
-                .thenReturn(List.of(101L));
-        when(eventRepository.filterUserEvents(
-                eq(List.of(101L)),
+        when(clubMemberRepository.findAllByUser_Id(1L))
+                .thenReturn(List.of(new ClubMember(umc, me, ClubRole.MEMBER)));
+        when(eventRepository.filterUserClubEvents(
+                eq(List.of(10L)),
                 eq(null),
                 eq(null),
                 eq(null),
@@ -186,13 +185,15 @@ class CalendarServiceTest {
     @Test
     void filterEvents_passesTrimmedNamesAndIds() throws Exception {
         Club umc = newClub(10L, "UMC");
+        User me = new User("dev-1", null, "kim", null);
+        setId(me, 1L);
         Event ot = newEvent(101L, umc, "OT", "2026-03-10T19:00:00");
         LocalDateTime start = LocalDateTime.parse("2026-03-01T00:00:00");
         LocalDateTime end = LocalDateTime.parse("2026-03-31T23:59:59");
-        when(registrationRepository.findEventIdsByUserIdAndStatuses(eq(1L), anyList()))
-                .thenReturn(List.of(101L));
-        when(eventRepository.filterUserEvents(
-                eq(List.of(101L)),
+        when(clubMemberRepository.findAllByUser_Id(1L))
+                .thenReturn(List.of(new ClubMember(umc, me, ClubRole.MEMBER)));
+        when(eventRepository.filterUserClubEvents(
+                eq(List.of(10L)),
                 eq(start),
                 eq(end),
                 eq("OT"),


### PR DESCRIPTION
기존엔 사용자가 등록한(REGISTERED/CHECKED_IN) 이벤트만 검색/필터 대상이라, 홈 시트에서 미등록 이벤트가 보이지 않는 문제 발생.

- EventRepository: searchInUserEvents/filterUserEvents 를 클럽 ID 기반의 searchInUserClubs/filterUserClubEvents 로 교체
- CalendarService: 두 메서드가 ClubMemberRepository 로 소속 클럽 ID 를 조회. 더 이상 사용되지 않는 RegistrationRepository 의존 제거
- CalendarServiceTest: 클럽 멤버십 기반으로 목 재구성

## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #2 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

-
-
-

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [ ] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 🔌 API 변경 사항 (해당 시)

<!-- API 변경이 있는 경우 작성해주세요. -->

| Method | Endpoint | 변경 내용 |
|--------|----------|-----------|
|        |          |           |

### Breaking Change
- [ ] ⚠️ Breaking Change 있음 (기존 API 변경)
- [ ] ✅ Breaking Change 없음

---

## 🧪 테스트

### 체크리스트

- [ ] `./gradlew build` 성공
- [ ] `./gradlew test` 통과
- [ ] 로컬에서 API 테스트 완료
- [ ] Postman/Swagger로 동작 확인

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->

```bash
# 예시
curl -X POST http://localhost:8080/api/events \
  -H "Content-Type: application/json" \
  -d '{"title": "테스트"}'
```

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->
