### PR TITLE
feat: 행사 컨텍스트로 클럽에 멱등 가입하는 엔드포인트 추가

### DIFF
--- a/src/main/java/team23/q_check/club/controller/ClubController.java
+++ b/src/main/java/team23/q_check/club/controller/ClubController.java
@@ -58,6 +58,16 @@ public class ClubController {
         return ApiResponse.ok(clubService.joinClub(currentUserId, request));
     }
 
+    @Operation(summary = "행사를 통해 해당 클럽에 가입 (이미 멤버면 멱등)")
+    @PostMapping("/join-via-event/{eventId}")
+    public ApiResponse<MyClubResponseDto> joinClubViaEvent(
+            @Parameter(hidden = true)
+            @CurrentUserId Long currentUserId,
+            @PathVariable Long eventId
+    ) {
+        return ApiResponse.ok(clubService.joinClubViaEvent(currentUserId, eventId));
+    }
+
     @Operation(summary = "내가 속한 클럽 목록 조회")
     @GetMapping
     public ApiResponse<List<MyClubResponseDto>> getMyClubs(

--- a/src/main/java/team23/q_check/club/domain/service/ClubService.java
+++ b/src/main/java/team23/q_check/club/domain/service/ClubService.java
@@ -17,6 +17,7 @@ import team23.q_check.club.domain.repository.ClubMemberRepository;
 import team23.q_check.club.domain.repository.ClubRepository;
 import team23.q_check.common.error.AppException;
 import team23.q_check.common.error.ErrorCode;
+import team23.q_check.event.domain.model.Event;
 import team23.q_check.event.domain.repository.EventRepository;
 import team23.q_check.identity.domain.model.User;
 import team23.q_check.identity.domain.repository.UserRepository;
@@ -100,6 +101,25 @@ public class ClubService {
         User currentUser = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "User not found: " + currentUserId));
 
+        clubMemberRepository.save(new ClubMember(club, currentUser, ClubRole.MEMBER));
+        return new MyClubResponseDto(club.getId(), club.getName(), club.getDescription(), ClubRole.MEMBER);
+    }
+
+    @Transactional
+    public MyClubResponseDto joinClubViaEvent(Long currentUserId, Long eventId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "Event not found: " + eventId));
+        Club club = event.getClub();
+
+        ClubMember existing = clubMemberRepository
+                .findByClub_IdAndUser_Id(club.getId(), currentUserId)
+                .orElse(null);
+        if (existing != null) {
+            return new MyClubResponseDto(club.getId(), club.getName(), club.getDescription(), existing.getRole());
+        }
+
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "User not found: " + currentUserId));
         clubMemberRepository.save(new ClubMember(club, currentUser, ClubRole.MEMBER));
         return new MyClubResponseDto(club.getId(), club.getName(), club.getDescription(), ClubRole.MEMBER);
     }

--- a/src/test/java/team23/q_check/club/service/ClubServiceTest.java
+++ b/src/test/java/team23/q_check/club/service/ClubServiceTest.java
@@ -253,6 +253,67 @@ class ClubServiceTest {
         assertEquals(ErrorCode.FORBIDDEN, exception.getErrorCode());
     }
 
+    @Test
+    void joinClubViaEvent_eventNotFound_throwsNotFound() {
+        when(eventRepository.findById(99L)).thenReturn(Optional.empty());
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> clubService.joinClubViaEvent(1L, 99L)
+        );
+        assertEquals(ErrorCode.NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    void joinClubViaEvent_existingMember_returnsCurrentRoleWithoutInsert() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null, "INV12345");
+        setId(club, 10L);
+        User me = new User("dev-1", null, "kim", null);
+        setId(me, 1L);
+        team23.q_check.event.domain.model.Event event = new team23.q_check.event.domain.model.Event(
+                club, "OT",
+                java.time.LocalDateTime.parse("2026-06-10T19:00:00"),
+                java.time.LocalDateTime.parse("2026-06-10T19:00:00"),
+                null, true);
+        ClubMember existing = new ClubMember(club, me, ClubRole.ADMIN);
+
+        when(eventRepository.findById(50L)).thenReturn(Optional.of(event));
+        when(clubMemberRepository.findByClub_IdAndUser_Id(10L, 1L)).thenReturn(Optional.of(existing));
+
+        MyClubResponseDto result = clubService.joinClubViaEvent(1L, 50L);
+
+        assertEquals(10L, result.clubId());
+        assertEquals(ClubRole.ADMIN, result.myRole());
+        verify(clubMemberRepository, never()).save(any(ClubMember.class));
+    }
+
+    @Test
+    void joinClubViaEvent_nonMember_savesAsMember() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null, "INV12345");
+        setId(club, 10L);
+        User me = new User("dev-1", null, "kim", null);
+        setId(me, 1L);
+        team23.q_check.event.domain.model.Event event = new team23.q_check.event.domain.model.Event(
+                club, "OT",
+                java.time.LocalDateTime.parse("2026-06-10T19:00:00"),
+                java.time.LocalDateTime.parse("2026-06-10T19:00:00"),
+                null, true);
+
+        when(eventRepository.findById(50L)).thenReturn(Optional.of(event));
+        when(clubMemberRepository.findByClub_IdAndUser_Id(10L, 1L)).thenReturn(Optional.empty());
+        when(userRepository.findById(1L)).thenReturn(Optional.of(me));
+
+        MyClubResponseDto result = clubService.joinClubViaEvent(1L, 50L);
+
+        assertEquals(10L, result.clubId());
+        assertEquals(ClubRole.MEMBER, result.myRole());
+
+        ArgumentCaptor<ClubMember> captor = ArgumentCaptor.forClass(ClubMember.class);
+        verify(clubMemberRepository).save(captor.capture());
+        assertEquals(ClubRole.MEMBER, captor.getValue().getRole());
+        assertEquals(1L, captor.getValue().getUser().getId());
+    }
+
     private void setId(Object target, Long id) throws Exception {
         Field field = target.getClass().getDeclaredField("id");
         field.setAccessible(true);


### PR DESCRIPTION
사전 등록 QR 을 스캔한 비멤버가 모달 확인 한 번으로 모임에 가입할 수
있도록, eventId 만으로 해당 행사의 클럽에 가입시키는 멱등 엔드포인트
추가.

- POST /api/clubs/join-via-event/{eventId}
- 이미 멤버면 현재 role 그대로 반환 (no-op), 비멤버면 MEMBER 로 가입
- 행사 없으면 404
- 서비스 단위 테스트 3건 추가 (event-not-found / existing-member / non-member)

## 📋 관련 이슈

<!-- 관련 이슈 번호를 입력해주세요. 예: #2 -->
Closes #

---

## 📝 변경 사항

<!-- 변경 사항을 간단히 설명해주세요. -->

-
-
-

---

## 🔄 변경 유형

<!-- 해당하는 항목에 [x]로 체크해주세요. -->

- [ ] ✨ Feature - 새 기능 추가
- [ ] 🔧 Change - 기존 기능 변경/삭제
- [ ] 🐛 Bug - 버그 수정
- [ ] 📚 Docs - 문서 수정
- [ ] ♻️ Refactor - 코드 리팩토링
- [ ] ⚙️ CI - CI/CD 설정 변경

---

## 🔌 API 변경 사항 (해당 시)

<!-- API 변경이 있는 경우 작성해주세요. -->

| Method | Endpoint | 변경 내용 |
|--------|----------|-----------|
|        |          |           |

### Breaking Change
- [ ] ⚠️ Breaking Change 있음 (기존 API 변경)
- [ ] ✅ Breaking Change 없음

---

## 🧪 테스트

### 체크리스트

- [ ] `./gradlew build` 성공
- [ ] `./gradlew test` 통과
- [ ] 로컬에서 API 테스트 완료
- [ ] Postman/Swagger로 동작 확인

### 테스트 방법

<!-- 리뷰어가 테스트할 수 있는 방법을 작성해주세요. -->

```bash
# 예시
curl -X POST http://localhost:8080/api/events \
  -H "Content-Type: application/json" \
  -d '{"title": "테스트"}'
```

---

## 📌 추가 정보

<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이벤트를 통한 클럽 가입 기능이 추가되었습니다. 기존 멤버인 경우 멱등하게 처리됩니다.

* **테스트**
  * 이벤트 기반 클럽 가입 시나리오에 대한 테스트 케이스가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Q-Check23/BackEnd/pull/36?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->