### PR TITLE
feat: 참가자 목록 응답에 체크인 시각(checkInTime) 추가

### DIFF
--- a/src/main/java/team23/q_check/event/domain/model/AttendanceLog.java
+++ b/src/main/java/team23/q_check/event/domain/model/AttendanceLog.java
@@ -53,6 +53,14 @@ public class AttendanceLog {
         return id;
     }
 
+    public Registration getRegistration() {
+        return registration;
+    }
+
+    public LocalDateTime getCheckInTime() {
+        return checkInTime;
+    }
+
     public AttendanceMethod getMethod() {
         return method;
     }

--- a/src/main/java/team23/q_check/event/domain/repository/AttendanceLogRepository.java
+++ b/src/main/java/team23/q_check/event/domain/repository/AttendanceLogRepository.java
@@ -3,7 +3,11 @@ package team23.q_check.event.domain.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import team23.q_check.event.domain.model.AttendanceLog;
 
+import java.util.List;
+
 public interface AttendanceLogRepository extends JpaRepository<AttendanceLog, Long> {
 
     void deleteAllByEvent_Id(Long eventId);
+
+    List<AttendanceLog> findAllByEvent_Id(Long eventId);
 }

--- a/src/main/java/team23/q_check/event/domain/service/RegistrationService.java
+++ b/src/main/java/team23/q_check/event/domain/service/RegistrationService.java
@@ -21,6 +21,8 @@ import team23.q_check.event.dto.RegistrationAnswerRequestDto;
 import team23.q_check.event.dto.RegistrationAnswerResponseDto;
 import team23.q_check.identity.domain.model.User;
 import team23.q_check.identity.domain.repository.UserRepository;
+import team23.q_check.event.domain.model.AttendanceLog;
+import team23.q_check.event.domain.repository.AttendanceLogRepository;
 import team23.q_check.event.domain.repository.EventRepository;
 import team23.q_check.event.domain.repository.FormAnswerRepository;
 import team23.q_check.event.domain.repository.FormFieldRepository;
@@ -37,6 +39,7 @@ public class RegistrationService {
     private final FormFieldRepository formFieldRepository;
     private final FormAnswerRepository formAnswerRepository;
     private final UserRepository userRepository;
+    private final AttendanceLogRepository attendanceLogRepository;
     private final ClubAuthorizationService clubAuthorizationService;
     private final ObjectMapper objectMapper;
 
@@ -46,6 +49,7 @@ public class RegistrationService {
             FormFieldRepository formFieldRepository,
             FormAnswerRepository formAnswerRepository,
             UserRepository userRepository,
+            AttendanceLogRepository attendanceLogRepository,
             ClubAuthorizationService clubAuthorizationService,
             ObjectMapper objectMapper
     ) {
@@ -54,6 +58,7 @@ public class RegistrationService {
         this.formFieldRepository = formFieldRepository;
         this.formAnswerRepository = formAnswerRepository;
         this.userRepository = userRepository;
+        this.attendanceLogRepository = attendanceLogRepository;
         this.clubAuthorizationService = clubAuthorizationService;
         this.objectMapper = objectMapper;
     }
@@ -148,6 +153,11 @@ public class RegistrationService {
                     ));
         }
 
+        Map<Long, LocalDateTime> checkInTimeByRegistrationId = new HashMap<>();
+        for (AttendanceLog log : attendanceLogRepository.findAllByEvent_Id(eventId)) {
+            checkInTimeByRegistrationId.put(log.getRegistration().getId(), log.getCheckInTime());
+        }
+
         return registrations.stream()
                 .map(registration -> new AdminRegistrationItemDto(
                         registration.getId(),
@@ -156,6 +166,7 @@ public class RegistrationService {
                         registration.getUser().getRealName(),
                         registration.getStatus().name(),
                         registration.getQrToken(),
+                        checkInTimeByRegistrationId.get(registration.getId()),
                         answersByRegistrationId.getOrDefault(registration.getId(), List.of())
                 ))
                 .toList();

--- a/src/main/java/team23/q_check/event/dto/AdminRegistrationItemDto.java
+++ b/src/main/java/team23/q_check/event/dto/AdminRegistrationItemDto.java
@@ -2,6 +2,7 @@ package team23.q_check.event.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Schema(description = "관리자 참가자 목록 아이템 DTO")
@@ -18,6 +19,8 @@ public record AdminRegistrationItemDto(
         String status,
         @Schema(example = "550e8400-e29b-41d4-a716-446655440000")
         String qrToken,
+        @Schema(description = "체크인 시각 (미체크인 시 null)", example = "2026-05-29T14:30:00")
+        LocalDateTime checkInTime,
         List<RegistrationAnswerResponseDto> answers
 ) {
 }

--- a/src/test/java/team23/q_check/event/controller/EventControllerTest.java
+++ b/src/test/java/team23/q_check/event/controller/EventControllerTest.java
@@ -160,6 +160,7 @@ class EventControllerTest {
                 .thenReturn(List.of(new AdminRegistrationItemDto(
                         200L, 7L, "kimjyun", "김지윤", "REGISTERED",
                         "550e8400-e29b-41d4-a716-446655440000",
+                        null,
                         List.of(new RegistrationAnswerResponseDto(11L, "식사 메뉴", "한식"))
                 )));
 

--- a/src/test/java/team23/q_check/event/service/RegistrationServiceTest.java
+++ b/src/test/java/team23/q_check/event/service/RegistrationServiceTest.java
@@ -15,6 +15,7 @@ import team23.q_check.event.domain.model.form.FormField;
 import team23.q_check.event.domain.service.RegistrationService;
 import team23.q_check.event.dto.CreateRegistrationRequestDto;
 import team23.q_check.event.dto.RegistrationAnswerRequestDto;
+import team23.q_check.event.domain.repository.AttendanceLogRepository;
 import team23.q_check.event.domain.repository.EventRepository;
 import team23.q_check.event.domain.repository.FormAnswerRepository;
 import team23.q_check.event.domain.repository.FormFieldRepository;
@@ -40,6 +41,7 @@ class RegistrationServiceTest {
     private FormFieldRepository formFieldRepository;
     private FormAnswerRepository formAnswerRepository;
     private UserRepository userRepository;
+    private AttendanceLogRepository attendanceLogRepository;
     private ClubAuthorizationService clubAuthorizationService;
     private RegistrationService registrationService;
 
@@ -50,6 +52,7 @@ class RegistrationServiceTest {
         formFieldRepository = mock(FormFieldRepository.class);
         formAnswerRepository = mock(FormAnswerRepository.class);
         userRepository = mock(UserRepository.class);
+        attendanceLogRepository = mock(AttendanceLogRepository.class);
         clubAuthorizationService = mock(ClubAuthorizationService.class);
         registrationService = new RegistrationService(
                 eventRepository,
@@ -57,6 +60,7 @@ class RegistrationServiceTest {
                 formFieldRepository,
                 formAnswerRepository,
                 userRepository,
+                attendanceLogRepository,
                 clubAuthorizationService,
                 new ObjectMapper()
         );


### PR DESCRIPTION
AttendanceLog.checkInTime을 행사별로 조회해 registrationId 기준으로 매핑, AdminRegistrationItemDto에 노출. 미체크인 참가자는 null.
