### PR TITLE
fix: 불참(CANCELED) 등록자도 QR 셀프 체크인 허용

### DIFF
--- a/src/main/java/team23/q_check/event/domain/service/AttendanceService.java
+++ b/src/main/java/team23/q_check/event/domain/service/AttendanceService.java
@@ -65,9 +65,8 @@ public class AttendanceService {
             throw new AppException(ErrorCode.CONFLICT, "Already checked in");
         }
 
-        if (registration.getStatus() == RegistrationStatus.CANCELED) {
-            throw new AppException(ErrorCode.CONFLICT, "Registration has been canceled");
-        }
+        // 불참(CANCELED) 등록자도 QR 입장 시 무조건 체크인되도록 허용한다.
+        // 현장에서 마음이 바뀐 참가자를 막지 않는다.
 
         User attendee = userRepository.findById(currentUserId)
                 .orElseThrow(() -> new AppException(ErrorCode.NOT_FOUND, "User not found: " + currentUserId));


### PR DESCRIPTION
현장에서 마음이 바뀐 불참자가 QR 입장 시 막히지 않도록
selfCheckIn의 CANCELED 차단을 제거하고 무조건 체크인 처리한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 등록이 취소된 상태의 참석자가 QR 코드로 행사에 현장 입장할 때 발생하던 오류가 해결되었습니다. 이제 이러한 참석자들도 정상적으로 입장 체크인이 가능합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Q-Check23/BackEnd/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->