### PR TITLE
fix: refresh_token 쿠키 SameSite 를 Strict 에서 Lax 로 완화

### DIFF
--- a/src/main/java/team23/q_check/identity/controller/AuthController.java
+++ b/src/main/java/team23/q_check/identity/controller/AuthController.java
@@ -152,7 +152,7 @@ public class AuthController {
                 .httpOnly(true)
                 .path("/")
                 .maxAge(0)
-                .sameSite("Strict")
+                .sameSite("Lax")
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, expired.toString());
         return ApiResponse.ok(null);
@@ -163,7 +163,7 @@ public class AuthController {
                 .httpOnly(true)
                 .path("/")
                 .maxAge(Duration.ofMillis(jwtProperties.refreshTokenExpiration()))
-                .sameSite("Strict")
+                .sameSite("Lax")
                 .build();
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }


### PR DESCRIPTION
## Summary
- QR 스캔으로 외부 컨텍스트에서 다시 들어올 때 자동로그인이 실패하던 문제 수정
- refresh_token 쿠키의 SameSite 속성을 `Strict` → `Lax` 로 변경 (set / 만료 양쪽 모두)

## 원인
- 액세스 토큰은 프론트엔드 메모리(Zustand)에만 저장 → 브라우저/탭 종료 시 사라짐 → cold start 마다 `POST /api/auth/refresh` 로만 세션 복구 가능
- refresh_token 쿠키가 `SameSite=Strict` 로 설정되어 있어 외부 진입(특히 카메라 앱에서 QR 링크 오픈 → iOS Safari) 케이스에서 일부 브라우저가 쿠키를 보내지 않아 refresh 가 401 → `ProtectedRoute` 가 `/landing` 으로 리다이렉트되어 자동로그인 실패로 관측됨

## 변경 내용
[AuthController.java:155, 166](https://github.com/Q-Check23/BackEnd/blob/fix/refresh-cookie-samesite-lax/src/main/java/team23/q_check/identity/controller/AuthController.java#L155-L166) — `setRefreshCookie()` 와 `logout()` 의 만료 쿠키 양쪽 모두 `.sameSite("Strict")` → `.sameSite("Lax")` 로 변경.

- Lax 는 cross-site POST 는 그대로 차단하므로 refresh token 의 CSRF 방어 의도는 유지됨
- set 시점과 만료 시점의 SameSite 가 다르면 브라우저가 동일 쿠키로 인식하지 못해 삭제가 안 되는 경우가 있어 양쪽을 함께 변경

## Test plan
- [ ] 로컬에서 로그인 → 브라우저 완전 종료 → 다시 접속 시 자동로그인 동작 확인
- [ ] 카메라 앱으로 QR 링크 스캔 후 외부 진입 시 자동로그인 동작 확인 (iOS Safari, Android Chrome)
- [ ] 로그아웃 후 refresh_token 쿠키가 정상 삭제되는지 확인 (devtools Application 탭)
- [ ] CI 빌드 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 새로고침 토큰 쿠키의 보안 속성을 조정하여 특정 상황에서의 호환성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->