### PR TITLE
feat: 회원가입 요청에 휴대폰 번호 필드 추가 (필수)

### DIFF
--- a/src/main/java/team23/q_check/identity/domain/service/AuthService.java
+++ b/src/main/java/team23/q_check/identity/domain/service/AuthService.java
@@ -72,8 +72,13 @@ public class AuthService {
             throw new AppException(ErrorCode.CONFLICT, "이미 사용 중인 아이디입니다");
         }
 
+        if (request.phone() == null || request.phone().isBlank()) {
+            throw new AppException(ErrorCode.INVALID_REQUEST, "휴대폰 번호를 입력해주세요");
+        }
+
         String discordId = jwtService.extractDiscordId(signupToken);
         User user = new User(discordId, request.email(), request.username(), request.name());
+        user.updatePhone(request.phone());
         userRepository.save(user);
 
         String accessToken = jwtService.issueAccessToken(user.getId());

--- a/src/main/java/team23/q_check/identity/dto/SignupRequestDto.java
+++ b/src/main/java/team23/q_check/identity/dto/SignupRequestDto.java
@@ -9,5 +9,7 @@ public record SignupRequestDto(
         @Schema(example = "qcheck_user", description = "아이디 (중복 불가)")
         String username,
         @Schema(example = "user@example.com", description = "이메일 (가입용 JWT의 이메일과 일치해야 함)")
-        String email
+        String email,
+        @Schema(example = "010-1234-5678", description = "휴대폰 번호 (사전등록 폼 자동채움에 사용)")
+        String phone
 ) {}

--- a/src/test/java/team23/q_check/identity/service/AuthServiceTest.java
+++ b/src/test/java/team23/q_check/identity/service/AuthServiceTest.java
@@ -127,7 +127,7 @@ class AuthServiceTest {
         when(jwtService.issueRefreshToken(7L)).thenReturn("refresh-token");
 
         TokenResult result = authService.signup("signup-token",
-                new SignupRequestDto("김지윤", "kimjyun", "kim@example.com"));
+                new SignupRequestDto("김지윤", "kimjyun", "kim@example.com", "010-1234-5678"));
 
         assertEquals(7L, result.userId());
         assertEquals("access-token", result.accessToken());
@@ -139,6 +139,7 @@ class AuthServiceTest {
         assertEquals("kim@example.com", captor.getValue().getEmail());
         assertEquals("kimjyun", captor.getValue().getUsername());
         assertEquals("김지윤", captor.getValue().getRealName());
+        assertEquals("010-1234-5678", captor.getValue().getPhone());
     }
 
     @Test
@@ -148,7 +149,7 @@ class AuthServiceTest {
         AppException exception = assertThrows(
                 AppException.class,
                 () -> authService.signup("not-signup",
-                        new SignupRequestDto("김지윤", "kimjyun", "kim@example.com"))
+                        new SignupRequestDto("김지윤", "kimjyun", "kim@example.com", "010-1234-5678"))
         );
         assertEquals(ErrorCode.UNAUTHORIZED, exception.getErrorCode());
     }
@@ -161,7 +162,7 @@ class AuthServiceTest {
         AppException exception = assertThrows(
                 AppException.class,
                 () -> authService.signup("signup-token",
-                        new SignupRequestDto("김지윤", "kimjyun", "other@example.com"))
+                        new SignupRequestDto("김지윤", "kimjyun", "other@example.com", "010-1234-5678"))
         );
         assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
     }
@@ -177,7 +178,7 @@ class AuthServiceTest {
         AppException exception = assertThrows(
                 AppException.class,
                 () -> authService.signup("signup-token",
-                        new SignupRequestDto("김지윤", "kimjyun", "kim@example.com"))
+                        new SignupRequestDto("김지윤", "kimjyun", "kim@example.com", "010-1234-5678"))
         );
         assertEquals(ErrorCode.CONFLICT, exception.getErrorCode());
     }
@@ -192,9 +193,25 @@ class AuthServiceTest {
         AppException exception = assertThrows(
                 AppException.class,
                 () -> authService.signup("signup-token",
-                        new SignupRequestDto("김지윤", "kimjyun", "kim@example.com"))
+                        new SignupRequestDto("김지윤", "kimjyun", "kim@example.com", "010-1234-5678"))
         );
         assertEquals(ErrorCode.CONFLICT, exception.getErrorCode());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void signup_phoneMissing_throwsInvalidRequest() {
+        when(jwtService.isSignupToken("signup-token")).thenReturn(true);
+        when(jwtService.extractEmail("signup-token")).thenReturn("kim@example.com");
+        when(userRepository.findByEmail("kim@example.com")).thenReturn(Optional.empty());
+        when(userRepository.existsByUsername("kimjyun")).thenReturn(false);
+
+        AppException exception = assertThrows(
+                AppException.class,
+                () -> authService.signup("signup-token",
+                        new SignupRequestDto("김지윤", "kimjyun", "kim@example.com", "  "))
+        );
+        assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
         verify(userRepository, never()).save(any(User.class));
     }
 


### PR DESCRIPTION
## Summary
- 사전등록/체크인 폼의 \"연락처 (전화번호)\" 필드 자동채움이 가능하도록 회원가입 시점에 phone 을 받아 \`User.phone\` 컬럼에 저장
- 프론트의 [EventRegistrationForm.guessProfileValue](https://github.com/Q-Check23/FrontEnd/blob/main/src/components/EventRegistrationForm.tsx#L21) 가 이미 phone 매칭 정규식을 가지고 있어, 가입 후 첫 사전등록 진입부터 곧바로 자동 채움

## 변경 내용
- \`SignupRequestDto\`: \`String phone\` 필드 추가 (Swagger 예시 포함)
- \`AuthService.signup\`: phone 이 null/blank 면 \`INVALID_REQUEST\` 로 거절. 통과하면 \`user.updatePhone(...)\` 으로 저장
- \`AuthServiceTest\`: 모든 기존 케이스에 phone 인자 추가, happy-path 에서 \`captor.getValue().getPhone()\` 검증, missing-phone 케이스 신규 추가

## DB
- 스키마 변경 없음. \`users.phone\` 컬럼은 nullable 로 이미 존재하므로 기존 가입자(NULL phone)도 영향 없음

## 배포 순서
**백엔드 먼저 머지·배포** → 프론트(phone 입력 UI) 머지. 반대 순서면 프론트가 보낸 phone 을 백엔드가 무시한 채 가입이 진행돼 자동채움이 안 됨

## Test plan
- [x] AuthServiceTest 전체 통과 (\`./gradlew test\`)
- [ ] 새 계정 가입 → 사전등록 페이지 진입 → \"연락처 (전화번호)\" 자동채움 확인 (프론트 PR 머지 후)
- [ ] 빈 phone 으로 가입 요청 시 400 INVALID_REQUEST 반환 확인