### PR TITLE
feat: 행사 생성 시 사전등록 정보 수집 토글 추가

### DIFF
--- a/src/main/java/team23/q_check/event/domain/model/Event.java
+++ b/src/main/java/team23/q_check/event/domain/model/Event.java
@@ -41,6 +41,9 @@ public class Event {
     @Column(precision = 10, scale = 2, nullable = false)
     private BigDecimal registerFee = BigDecimal.ZERO;
 
+    @Column(name = "collect_registration_info", nullable = false)
+    private Boolean collectRegistrationInfo = true;
+
     protected Event() {
     }
 
@@ -52,7 +55,7 @@ public class Event {
             String location,
             Boolean isActive
     ) {
-        this(club, title, null, startTime, endTime, location, null, isActive, BigDecimal.ZERO);
+        this(club, title, null, startTime, endTime, location, null, isActive, BigDecimal.ZERO, true);
     }
 
     public Event(
@@ -66,6 +69,21 @@ public class Event {
             Boolean isActive,
             BigDecimal registerFee
     ) {
+        this(club, title, description, startTime, endTime, location, discordChannelId, isActive, registerFee, true);
+    }
+
+    public Event(
+            Club club,
+            String title,
+            String description,
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            String location,
+            String discordChannelId,
+            Boolean isActive,
+            BigDecimal registerFee,
+            Boolean collectRegistrationInfo
+    ) {
         this.club = club;
         this.title = title;
         this.description = description;
@@ -75,6 +93,7 @@ public class Event {
         this.discordChannelId = discordChannelId;
         this.isActive = isActive == null ? Boolean.TRUE : isActive;
         this.registerFee = registerFee == null ? BigDecimal.ZERO : registerFee;
+        this.collectRegistrationInfo = collectRegistrationInfo == null ? Boolean.TRUE : collectRegistrationInfo;
     }
 
     public Long getId() {
@@ -115,6 +134,10 @@ public class Event {
 
     public BigDecimal getRegisterFee() {
         return registerFee;
+    }
+
+    public Boolean getCollectRegistrationInfo() {
+        return collectRegistrationInfo;
     }
 
     public void update(

--- a/src/main/java/team23/q_check/event/domain/service/EventService.java
+++ b/src/main/java/team23/q_check/event/domain/service/EventService.java
@@ -112,6 +112,7 @@ public class EventService {
             }
         }
 
+        boolean collectInfo = !Boolean.FALSE.equals(request.collectRegistrationInfo());
         Event event = new Event(
                 club,
                 request.title().trim(),
@@ -121,11 +122,15 @@ public class EventService {
                 request.location(),
                 discordChannelId,
                 true,
-                registerFee
+                registerFee,
+                collectInfo
         );
         Event savedEvent = eventRepository.save(event);
 
-        List<FormField> fields = createFormFields(savedEvent, request.formFields());
+        // 정보 수집을 안 받기로 한 행사는 폼 필드 자체를 만들지 않음 — 토글 ON 으로 바꿨다 다시 OFF 한 케이스를 막기 위함
+        List<FormField> fields = collectInfo
+                ? createFormFields(savedEvent, request.formFields())
+                : Collections.emptyList();
         return toDetailDto(savedEvent, fields);
     }
 
@@ -284,6 +289,7 @@ public class EventService {
                 event.getDiscordChannelId(),
                 event.getRegisterFee(),
                 event.getIsActive(),
+                event.getCollectRegistrationInfo(),
                 fieldDtos
         );
     }

--- a/src/main/java/team23/q_check/event/dto/CreateEventRequestDto.java
+++ b/src/main/java/team23/q_check/event/dto/CreateEventRequestDto.java
@@ -26,6 +26,9 @@ public record CreateEventRequestDto(
         String discordChannelId,
         @Schema(description = "참가비(원)", example = "10000")
         BigDecimal registerFee,
+        @Schema(description = "사전등록 시 참가자 정보(폼) 수집 여부. null/true면 폼 수집, false면 폼 없이 원클릭 등록. 생성 시에만 지정 가능 (수정 불가)",
+                example = "true")
+        Boolean collectRegistrationInfo,
         List<FormFieldRequestDto> formFields
 ) {
 }

--- a/src/main/java/team23/q_check/event/dto/EventDetailResponseDto.java
+++ b/src/main/java/team23/q_check/event/dto/EventDetailResponseDto.java
@@ -27,6 +27,9 @@ public record EventDetailResponseDto(
         BigDecimal registerFee,
         @Schema(example = "true")
         Boolean isActive,
+        @Schema(description = "사전등록 시 참가자 정보(폼) 수집 여부. false 면 프론트는 폼 없이 원클릭 등록 UI 를 표시",
+                example = "true")
+        Boolean collectRegistrationInfo,
         List<FormFieldResponseDto> formFields
 ) {
 }

--- a/src/main/resources/db/migration/V11__add_collect_registration_info_to_events.sql
+++ b/src/main/resources/db/migration/V11__add_collect_registration_info_to_events.sql
@@ -1,0 +1,2 @@
+alter table events
+    add column collect_registration_info bit not null default 1;

--- a/src/test/java/team23/q_check/event/controller/EventControllerTest.java
+++ b/src/test/java/team23/q_check/event/controller/EventControllerTest.java
@@ -55,7 +55,7 @@ class EventControllerTest {
                 new EventDetailResponseDto(
                         100L, 1L, "OT", null,
                         "2026-03-10T19:00", null, null, null,
-                        java.math.BigDecimal.ZERO, true,
+                        java.math.BigDecimal.ZERO, true, true,
                         List.of(new FormFieldResponseDto(1L, "TEXT", "학번", true, List.of()))
                 )
         );
@@ -99,7 +99,7 @@ class EventControllerTest {
                 new EventDetailResponseDto(
                         100L, 1L, "OT", null,
                         "2026-03-10T19:00", "2026-03-10T22:00", "강남", null,
-                        java.math.BigDecimal.ZERO, true, List.of())
+                        java.math.BigDecimal.ZERO, true, true, List.of())
         );
 
         mockMvc.perform(get("/api/events/100"))

--- a/src/test/java/team23/q_check/event/service/EventServiceTest.java
+++ b/src/test/java/team23/q_check/event/service/EventServiceTest.java
@@ -37,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -112,6 +113,7 @@ class EventServiceTest {
                         null,
                         null,
                         null,
+                        null,
                         List.of(new FormFieldRequestDto("SELECT", "식사 메뉴", true, List.of("한식", "양식")))
                 )
         );
@@ -138,6 +140,7 @@ class EventServiceTest {
                                 "OT",
                                 null,
                                 "2026-03-10T19:00:00",
+                                null,
                                 null,
                                 null,
                                 null,
@@ -179,6 +182,7 @@ class EventServiceTest {
                         true,
                         "1234567890",
                         new BigDecimal("10000"),
+                        null,
                         List.of()
                 )
         );
@@ -196,6 +200,47 @@ class EventServiceTest {
     }
 
     @Test
+    void createEvent_collectRegistrationInfoFalse_skipsFormFieldsAndPersistsFlag() throws Exception {
+        Club club = new Club("UMC", "desc", "guild-1", null, "INV12345");
+        setId(club, 1L);
+        User admin = new User("dev-1", null, "admin", null);
+        ClubMember adminMembership = new ClubMember(club, admin, ClubRole.ADMIN);
+        when(clubRepository.existsById(1L)).thenReturn(true);
+        when(clubAuthorizationService.requireAdminOrOwner(1L, 1L)).thenReturn(adminMembership);
+
+        Event saved = new Event(club, "OT",
+                LocalDateTime.parse("2026-03-10T19:00:00"),
+                LocalDateTime.parse("2026-03-10T19:00:00"),
+                null, true);
+        setId(saved, 100L);
+        when(eventRepository.save(any(Event.class))).thenAnswer(invocation -> {
+            Event toSave = invocation.getArgument(0);
+            setId(toSave, 100L);
+            return toSave;
+        });
+
+        var result = eventService.createEvent(
+                1L,
+                new CreateEventRequestDto(
+                        1L, "OT", null,
+                        "2026-03-10T19:00:00", null, null, null, null, null,
+                        false,
+                        List.of(new FormFieldRequestDto("TEXT", "학번", true, List.of()))
+                )
+        );
+
+        // 토글 OFF 면 응답의 formFields 는 비어 있어야 하고, 플래그는 false 로 노출
+        assertEquals(Boolean.FALSE, result.collectRegistrationInfo());
+        assertEquals(0, result.formFields().size());
+        // formFieldRepository.save 가 호출되지 않았는지 확인 (필드 자체를 만들지 않음)
+        verify(formFieldRepository, never()).save(any());
+
+        ArgumentCaptor<Event> captor = ArgumentCaptor.forClass(Event.class);
+        verify(eventRepository).save(captor.capture());
+        assertEquals(Boolean.FALSE, captor.getValue().getCollectRegistrationInfo());
+    }
+
+    @Test
     void createEvent_endTimeBeforeStart_throwsInvalidRequest() throws Exception {
         Club club = new Club("UMC", "desc", "guild-1", null, "INV12345");
         setId(club, 1L);
@@ -208,7 +253,7 @@ class EventServiceTest {
                 () -> eventService.createEvent(1L, new CreateEventRequestDto(
                         1L, "OT", null,
                         "2026-03-10T19:00:00", "2026-03-10T18:00:00",
-                        null, null, null, null, List.of()
+                        null, null, null, null, null, List.of()
                 ))
         );
         assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());
@@ -226,7 +271,7 @@ class EventServiceTest {
                 AppException.class,
                 () -> eventService.createEvent(1L, new CreateEventRequestDto(
                         1L, "OT", null, "2026-03-10T19:00:00", null, null, null, null,
-                        new BigDecimal("-1"), List.of()
+                        new BigDecimal("-1"), null, List.of()
                 ))
         );
         assertEquals(ErrorCode.INVALID_REQUEST, exception.getErrorCode());


### PR DESCRIPTION
## Summary
- 운영진이 행사 만들 때 \"사전등록 시 참가자 정보(폼)를 수집할지 말지\"를 토글로 선택 가능
- OFF 면 서버는 폼 필드 자체를 만들지 않고, 응답에 빈 \`formFields\` 와 \`collectRegistrationInfo: false\` 를 내려보냄 → 프론트는 폼 없이 원클릭 등록 UI 를 그림
- 운영진 결정: 토글은 **생성 시점에만 설정**, 수정 단계에선 변경 불가 (멤버가 폼 봤다 안 봤다 하는 혼란 방지)

## 변경 내용
### DB
- \`V11__add_collect_registration_info_to_events.sql\` — \`events.collect_registration_info bit not null default 1\` 추가
- 기존 행사는 기본값 1 (\`true\`) 로 마이그레이션 → 동작 변함 없음

### 도메인 / DTO
- \`Event\` 엔티티: \`collectRegistrationInfo\` 필드 + getter, 10-인자 생성자 신설. 9-인자 / 6-인자는 기본값 \`true\` 위임 형태라 **기존 호출부 47곳 (테스트) 무영향**
- \`CreateEventRequestDto\`: \`Boolean collectRegistrationInfo\` (optional, null 은 true 로 해석)
- \`EventDetailResponseDto\`: 같은 플래그 응답 노출
- \`UpdateEventRequestDto\`: **변경 없음** — 수정 단계에선 토글 변경 불가

### 서비스
- \`EventService.createEvent\`: \`collectInfo\` 가 \`false\` 면 \`createFormFields\` 호출 자체를 스킵하고 빈 리스트로 응답. 클라이언트가 폼 필드와 토글을 동시에 보내도 토글이 우선
- \`RegistrationService\` 무변경 — 기존 \`validateAnswers\` 가 빈 fields / 빈 answers 케이스를 이미 통과시킴

### 테스트
- 기존 EventService/EventController 테스트의 DTO 생성자 인자에 새 파라미터 추가 (null 로 기본값 유지)
- 신규: \`createEvent_collectRegistrationInfoFalse_skipsFormFieldsAndPersistsFlag\` — 토글 OFF 시 \`formFieldRepository.save\` 가 호출되지 않고 응답 \`formFields\` 가 비며 플래그가 \`false\` 로 저장되는지 검증

## 배포 순서
백엔드 PR 먼저 머지·배포 → 프론트 PR 머지. 반대 순서면 프론트가 \`undefined\` 를 받게 되는데, 명시 \`=== false\` 비교라 안전 (undefined → 기본 폼 표시)

## Test plan
- [x] \`./gradlew test\` 전체 통과
- [ ] 운영진 계정으로 토글 OFF 행사 생성 → 멤버가 사전등록 링크 진입 → 폼 없이 \"참여하기\" 버튼만 보이는지 확인 (프론트 PR 머지 후)
- [ ] 토글 ON 행사는 기존과 동일한 폼 보이는지 회귀 확인
- [ ] DB: \`SELECT id, collect_registration_info FROM events;\` 로 플래그 저장 확인