### PR TITLE
feat: /api/auth/login 에 silent 플래그 (prompt=none) + 실패 시 자동 폴백

### DIFF
--- a/src/main/java/team23/q_check/identity/controller/AuthController.java
+++ b/src/main/java/team23/q_check/identity/controller/AuthController.java
@@ -34,6 +34,9 @@ public class AuthController {
 
     private static final Logger log = LoggerFactory.getLogger(AuthController.class);
     private static final String OAUTH_STATE_SESSION_KEY = "oauth2_state";
+    // 가장 최근 OAuth 시도가 prompt=none(silent) 이었는지. 콜백에서 Discord 가 error 로
+    // 돌려보냈을 때 일반 동의 흐름으로 자동 재시도할지 판단하는 가드.
+    private static final String OAUTH_SILENT_SESSION_KEY = "oauth2_silent";
 
     private final AuthService authService;
     private final JwtProperties jwtProperties;
@@ -45,12 +48,19 @@ public class AuthController {
         this.frontendProperties = frontendProperties;
     }
 
-    @Operation(summary = "Discord 로그인 리다이렉트", description = "Discord OAuth2 인증 페이지로 리다이렉트합니다")
+    @Operation(
+            summary = "Discord 로그인 리다이렉트",
+            description = "Discord OAuth2 인증 페이지로 리다이렉트합니다. " +
+                    "silent=true 면 prompt=none 을 붙여 이미 인가된 사용자의 동의 화면을 건너뜁니다. " +
+                    "Discord 가 error 로 응답하면 자동으로 일반 흐름으로 재시도합니다."
+    )
     @GetMapping("/login")
-    public void login(HttpServletRequest request, HttpServletResponse response) throws IOException {
-        String state = UUID.randomUUID().toString();
-        request.getSession(true).setAttribute(OAUTH_STATE_SESSION_KEY, state);
-        response.sendRedirect(authService.getAuthorizationUrl(state));
+    public void login(
+            @RequestParam(required = false) Boolean silent,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) throws IOException {
+        initiateOAuth(request, response, Boolean.TRUE.equals(silent));
     }
 
     @Operation(
@@ -59,17 +69,39 @@ public class AuthController {
                     "프론트의 콜백 라우트(FRONTEND_AUTH_CALLBACK_URL)로 302 redirect 합니다. " +
                     "기존 회원: ?token=<accessJwt>&isNewUser=false (+ refresh token httpOnly 쿠키). " +
                     "신규 회원: ?token=<signupJwt>&isNewUser=true. " +
-                    "에러: ?error=<코드>&message=<설명>."
+                    "에러: ?error=<코드>&message=<설명>. " +
+                    "silent 시도가 Discord 에서 error 로 돌아오면 일반 흐름으로 자동 재시도합니다."
     )
     @GetMapping("/code")
     public void handleCode(
-            @RequestParam String code,
+            @RequestParam(required = false) String code,
             @RequestParam(required = false) String state,
+            @RequestParam(required = false) String error,
             HttpServletRequest request,
             HttpServletResponse response
     ) throws IOException {
+        // Discord 가 error 로 응답한 경우: silent 시도였다면 일반 흐름으로 자동 재시도,
+        // 아니면 프론트에 에러 전달
+        if (error != null) {
+            boolean wasSilent = consumeSilentFlag(request);
+            if (wasSilent) {
+                log.info("auth.code.silent_failed error={} retrying with consent", error);
+                initiateOAuth(request, response, false);
+                return;
+            }
+            log.warn("auth.code.discord_error error={}", error);
+            response.sendRedirect(buildErrorUrl("OAUTH_ERROR", "Discord 인증에 실패했습니다"));
+            return;
+        }
+
+        if (code == null) {
+            response.sendRedirect(buildErrorUrl("INVALID_REQUEST", "code 파라미터가 필요합니다"));
+            return;
+        }
+
         try {
             validateOAuthState(request, state);
+            consumeSilentFlag(request);
             CodeResult result = authService.processCode(code);
             if (!result.isNewUser()) {
                 setRefreshCookie(response, result.refreshToken());
@@ -79,6 +111,26 @@ public class AuthController {
             log.warn("auth.code.error code={} msg={}", e.getErrorCode().getCode(), e.getMessage());
             response.sendRedirect(buildErrorUrl(e.getErrorCode().getCode(), e.getMessage()));
         }
+    }
+
+    private void initiateOAuth(HttpServletRequest request, HttpServletResponse response, boolean silent) throws IOException {
+        String state = UUID.randomUUID().toString();
+        HttpSession session = request.getSession(true);
+        session.setAttribute(OAUTH_STATE_SESSION_KEY, state);
+        if (silent) {
+            session.setAttribute(OAUTH_SILENT_SESSION_KEY, Boolean.TRUE);
+        } else {
+            session.removeAttribute(OAUTH_SILENT_SESSION_KEY);
+        }
+        response.sendRedirect(authService.getAuthorizationUrl(state, silent));
+    }
+
+    private boolean consumeSilentFlag(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session == null) return false;
+        Object flag = session.getAttribute(OAUTH_SILENT_SESSION_KEY);
+        session.removeAttribute(OAUTH_SILENT_SESSION_KEY);
+        return Boolean.TRUE.equals(flag);
     }
 
     private String buildSuccessUrl(CodeResult result) {

--- a/src/main/java/team23/q_check/identity/domain/service/AuthService.java
+++ b/src/main/java/team23/q_check/identity/domain/service/AuthService.java
@@ -113,7 +113,11 @@ public class AuthService {
     }
 
     public String getAuthorizationUrl(String state) {
-        return discordOAuthService.getAuthorizationUrl(state);
+        return discordOAuthService.getAuthorizationUrl(state, false);
+    }
+
+    public String getAuthorizationUrl(String state, boolean silent) {
+        return discordOAuthService.getAuthorizationUrl(state, silent);
     }
 
     /**

--- a/src/main/java/team23/q_check/identity/domain/service/DiscordOAuthService.java
+++ b/src/main/java/team23/q_check/identity/domain/service/DiscordOAuthService.java
@@ -29,14 +29,28 @@ public class DiscordOAuthService {
     }
 
     public String getAuthorizationUrl(String state) {
-        return UriComponentsBuilder.fromUriString(discordProps.oauthUrl())
+        return getAuthorizationUrl(state, false);
+    }
+
+    /**
+     * Discord OAuth 인증 URL을 생성한다.
+     *
+     * @param state CSRF 방지용 랜덤 state
+     * @param silent true 면 prompt=none 을 붙여 이미 인가된 사용자에 대해 동의 화면을
+     *               건너뛰고 즉시 redirect 한다. 인가가 안 돼 있으면 Discord 가 error
+     *               로 돌려보내므로 호출자는 그 경우를 폴백(일반 흐름 재시도) 해야 한다.
+     */
+    public String getAuthorizationUrl(String state, boolean silent) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(discordProps.oauthUrl())
                 .queryParam("client_id", discordProps.clientId())
                 .queryParam("redirect_uri", discordProps.redirectUri())
                 .queryParam("response_type", "code")
                 .queryParam("scope", "identify email")
-                .queryParam("state", state)
-                .build()
-                .toUriString();
+                .queryParam("state", state);
+        if (silent) {
+            builder.queryParam("prompt", "none");
+        }
+        return builder.build().toUriString();
     }
 
     public DiscordTokenResponse exchangeCode(String code) {

--- a/src/test/java/team23/q_check/identity/controller/AuthControllerTest.java
+++ b/src/test/java/team23/q_check/identity/controller/AuthControllerTest.java
@@ -17,7 +17,11 @@ import team23.q_check.identity.domain.service.AuthService.CodeResult;
 import team23.q_check.identity.domain.service.AuthService.TokenResult;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -25,6 +29,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class AuthControllerTest {
@@ -50,7 +55,8 @@ class AuthControllerTest {
 
     @Test
     void login_redirectsToDiscordAndStoresStateInSession() throws Exception {
-        when(authService.getAuthorizationUrl(any())).thenReturn("https://discord.com/oauth2/authorize?...");
+        when(authService.getAuthorizationUrl(any(), anyBoolean()))
+                .thenReturn("https://discord.com/oauth2/authorize?...");
 
         var result = mockMvc.perform(get("/api/auth/login"))
                 .andExpect(status().is3xxRedirection())
@@ -60,6 +66,54 @@ class AuthControllerTest {
         HttpSession session = result.getRequest().getSession(false);
         assert session != null;
         assert session.getAttribute(OAUTH_STATE_SESSION_KEY) != null;
+        assert session.getAttribute("oauth2_silent") == null;
+    }
+
+    @Test
+    void login_silent_storesSilentFlagAndPassesSilentToAuthService() throws Exception {
+        when(authService.getAuthorizationUrl(any(), anyBoolean()))
+                .thenReturn("https://discord.com/oauth2/authorize?prompt=none&...");
+
+        var result = mockMvc.perform(get("/api/auth/login").param("silent", "true"))
+                .andExpect(status().is3xxRedirection())
+                .andReturn();
+
+        HttpSession session = result.getRequest().getSession(false);
+        assert session != null;
+        assert Boolean.TRUE.equals(session.getAttribute("oauth2_silent"));
+        verify(authService).getAuthorizationUrl(any(), eq(true));
+    }
+
+    @Test
+    void handleCode_silentError_retriesWithoutSilent() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute("oauth2_silent", Boolean.TRUE);
+        when(authService.getAuthorizationUrl(any(), eq(false)))
+                .thenReturn("https://discord.com/oauth2/authorize?...");
+
+        mockMvc.perform(get("/api/auth/code")
+                        .session(session)
+                        .param("error", "interaction_required"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrl("https://discord.com/oauth2/authorize?..."));
+
+        // 자동 재시도는 silent 플래그를 해제하고 일반 흐름으로 한 번만 시도
+        assert session.getAttribute("oauth2_silent") == null;
+        verify(authService).getAuthorizationUrl(any(), eq(false));
+        verify(authService, never()).processCode(any());
+    }
+
+    @Test
+    void handleCode_nonSilentError_redirectsToFrontWithOauthError() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+
+        mockMvc.perform(get("/api/auth/code")
+                        .session(session)
+                        .param("error", "access_denied"))
+                .andExpect(status().is3xxRedirection())
+                .andExpect(redirectedUrlPattern(FRONT_CALLBACK + "?error=OAUTH_ERROR*"));
+
+        verify(authService, never()).processCode(any());
     }
 
     @Test


### PR DESCRIPTION
## Summary
QR 스캔으로 보호 경로에 들어왔다가 자동 재인증되는 흐름에서 Discord 동의 화면이 매번 뜨던 문제 해결.

- \`GET /api/auth/login?silent=true\` 옵션 추가 → 백엔드가 \`prompt=none\` 붙은 Discord OAuth URL 로 redirect
- 이미 디스코드 앱을 인가한 사용자는 동의 화면 없이 곧바로 \`/api/auth/code\` 로 돌아옴 (사실상 자동로그인)
- 인가 안 된 사용자에 대해 Discord 가 error 로 응답하면 백엔드가 일반 흐름(prompt 없음)으로 자동 재시도. 사용자는 동의 화면 한 번만 보면 됨

## 배경
Discord OAuth 의 **기본 동작은 매번 동의 화면을 보여주는 것** — 디스코드 정책 강제가 아니라 단순 default. \`prompt=none\` 파라미터로 \"이미 인가된 사용자면 동의 건너뛰기\" 동작이 가능. 단 첫 가입자나 인가 취소한 사용자에 대해선 error 응답이 오므로 폴백이 필요.

## 변경 내용
- \`DiscordOAuthService.getAuthorizationUrl(state, silent)\` 오버로드 추가. silent=true 면 \`prompt=none\` 쿼리파라미터 추가
- \`AuthService\` 에도 동일 오버로드 노출
- \`AuthController.login\` 에 \`silent\` 쿼리파라미터 받음. 세션에 \`oauth2_silent\` 가드 저장
- \`AuthController.handleCode\` 가 Discord 에서 error 응답을 받았을 때:
  - 가드가 켜져 있으면 → 일반 흐름(prompt=none 없이)으로 자동 재시도. 가드는 항상 해제하여 무한 루프 방지
  - 가드가 꺼져 있으면 → \`OAUTH_ERROR\` 로 프론트 콜백에 전달
- code 가 null 인 케이스도 명시적으로 INVALID_REQUEST 로 처리

## 시나리오별 동작
| 케이스 | 이전 | 이후 |
|---|---|---|
| silent=true + 이미 인가됨 | (silent 없음) 동의 화면 표시 | 동의 화면 없이 즉시 복귀 |
| silent=true + 미인가 | (silent 없음) 동의 화면 표시 | Discord error → 자동 재시도 → 동의 화면 표시 |
| silent 없음 (수동 클릭) | 동의 화면 표시 | 동일 |
| Discord error (silent 아님) | code 누락으로 INVALID_REQUEST 500 가능 | OAUTH_ERROR 로 프론트에 깔끔히 전달 |

## Test plan
- [x] AuthServiceTest, AuthControllerTest 전체 통과 (\`./gradlew test\`)
- [x] login_silent_storesSilentFlagAndPassesSilentToAuthService
- [x] handleCode_silentError_retriesWithoutSilent
- [x] handleCode_nonSilentError_redirectsToFrontWithOauthError
- [ ] 운영 배포 후: 디스코드로 가입한 폰에서 로그아웃 → /checkin 직접 진입 → /login-landing 자동 트리거 → 동의 화면 없이 복귀
- [ ] 인가 취소(Discord 설정에서) 한 사용자 케이스도 자동 폴백 후 동의 화면 한 번 표시되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Discord 로그인 시 자동 재시도 기능 추가: 자동 동의 모드에서 에러 발생 시 일반 동의 흐름으로 자동 전환
  * Silent 모드 지원으로 이미 인증된 사용자에게 더 부드러운 로그인 경험 제공

* **Bug Fixes**
  * OAuth 콜백 처리 개선: 누락된 인증 코드 및 에러 파라미터에 대한 안정적인 처리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->